### PR TITLE
refine premium navigation and hero ctAs

### DIFF
--- a/espace_coach.html
+++ b/espace_coach.html
@@ -1,156 +1,275 @@
-
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Espace coach – Tennis Impact</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      background: #f5f6fb;
+      color: var(--color-navy);
+    }
 
-<style>
-.bouton-retour-fixe {
-  position: fixed !important;
-  top: 20px;
-  left: 20px;
-  background-color: #c9a33c;
-  color: white;
-  padding: 12px 20px;
-  font-size: 0.95em;
-  border-radius: 30px;
-  text-decoration: none;
-  z-index: 99999 !important;
-  box-shadow: 0 4px 10px rgba(0,0,0,0.15);
-  transition: background 0.3s ease;
-}
-.bouton-retour-fixe:hover {
-  background-color: #b08e2c;
-}
-</style>
+    .hero-coach {
+      position: relative;
+      padding: 120px 0 90px;
+      background: linear-gradient(120deg, rgba(5, 10, 15, 0.85), rgba(20, 44, 69, 0.9)),
+        url('https://images.unsplash.com/photo-1503185912284-5271ff81b9a8?auto=format&fit=crop&w=1800&q=80') center/cover;
+      color: var(--color-white);
+    }
 
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Espace Coach - Tennis Impact</title>
-  <link rel="stylesheet" href="style.css">
+    .hero-coach h1 {
+      font-family: var(--font-heading);
+      font-size: clamp(2.6rem, 4vw, 3.3rem);
+      margin-bottom: 1rem;
+    }
+
+    .hero-coach p {
+      max-width: 680px;
+      font-size: 1.1rem;
+      margin-bottom: 2rem;
+    }
+
+    .benefits-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.5rem;
+      margin-top: 3rem;
+    }
+
+    .benefit-card {
+      background: rgba(255, 255, 255, 0.08);
+      border-radius: var(--radius-card);
+      padding: 1.8rem;
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      backdrop-filter: blur(14px);
+    }
+
+    .benefit-card h3 {
+      font-size: 1.05rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .content-section {
+      padding: 80px 0;
+    }
+
+    .content-section .section__grid {
+      align-items: center;
+      gap: 3rem;
+    }
+
+    .coach-visual {
+      border-radius: var(--radius-large);
+      overflow: hidden;
+      box-shadow: var(--shadow-soft);
+    }
+
+    .engagement-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+      margin-top: 3rem;
+    }
+
+    .engagement-card {
+      background: var(--color-white);
+      border-radius: var(--radius-card);
+      padding: 2rem;
+      box-shadow: var(--shadow-soft);
+    }
+
+    .form-card {
+      background: var(--color-night);
+      color: var(--color-white);
+      padding: clamp(2.5rem, 4vw, 3.5rem);
+      border-radius: var(--radius-large);
+      box-shadow: var(--shadow-strong);
+      max-width: 780px;
+      margin: 0 auto 100px;
+    }
+
+    .form-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+      margin-top: 2rem;
+    }
+
+    .form-grid input,
+    .form-grid textarea,
+    .form-grid select {
+      width: 100%;
+      padding: 0.95rem 1.1rem;
+      border-radius: 12px;
+      border: none;
+      font-size: 0.95rem;
+    }
+
+    .form-grid textarea {
+      min-height: 140px;
+      resize: vertical;
+    }
+
+    .form-card button {
+      margin-top: 1.5rem;
+    }
+  </style>
 </head>
 <body>
-
-<div style="position: absolute; top: 20px; left: 20px; z-index: 9999;">
-  <a href="index.html" class="btn-retour" style="padding: 10px 20px; background-color: #FFD700; color: black; font-weight: bold; border-radius: 5px; text-decoration: none;">← Retour à l'accueil</a>
-</div>
-
-
-<a href="index.html" style="position: fixed; top: 20px; left: 20px; background-color: #c9a33c; color: white; padding: 12px 20px; font-size: 0.95em; border-radius: 30px; text-decoration: none; z-index: 999999; box-shadow: 0 4px 10px rgba(0,0,0,0.15); transition: background 0.3s ease;">← Retour à l’accueil</a>
-
-
-
-<a href="index.html" style="
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  background-color: #c9a33c;
-  color: white;
-  padding: 12px 20px;
-  font-size: 0.95em;
-  border-radius: 30px;
-  text-decoration: none;
-  z-index: 1000;
-  box-shadow: 0 4px 10px rgba(0,0,0,0.15);
-  transition: background 0.3s ease;
-" onmouseover="this.style.backgroundColor='#b08e2c'" onmouseout="this.style.backgroundColor='#c9a33c'">
-← Retour à l’accueil
-</a>
-
-
-<a href="index.html" style="
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  background-color: #c9a33c;
-  color: white;
-  padding: 12px 20px;
-  font-size: 0.95em;
-  border-radius: 30px;
-  text-decoration: none;
-  z-index: 1000;
-  box-shadow: 0 4px 10px rgba(0,0,0,0.15);
-  transition: background 0.3s ease;
-" onmouseover="this.style.backgroundColor='#b08e2c'" onmouseout="this.style.backgroundColor='#c9a33c'">
-← Retour à l’accueil
-</a>
-
-
-
-
-<section style="position: relative; height: 400px; overflow: hidden;">
-  <img src="images/2.png" alt="Espace Coach" style="width: 100%; height: 100%; object-fit: cover;">
-  <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); color: white; text-align: center;">
-    <h1 style="font-size: 3em; text-shadow: 2px 2px 8px rgba(0,0,0,0.6);">Espace Coach</h1>
-    <p style="font-size: 1.2em; text-shadow: 1px 1px 6px rgba(0,0,0,0.6);">Rejoignez l’aventure Tennis Impact</p>
-  </div>
-</section>
-
-<section style="background:#ffffff; padding:60px 20px; color:#0c2340;">
-  <div style="max-width:1100px; margin:0 auto;">
-    <div style="background:white; padding:40px; border-radius:12px; box-shadow:0 8px 24px rgba(0,0,0,0.08);">
-
-      <h2 style="color:#c9a33c; font-size:1.8em; margin-bottom:15px;">Qu’est-ce que le contrat apporteur ?</h2>
-      <p style="font-size:1.1em; line-height:1.7;">
-        Le contrat apporteur d’affaires permet à un coach, un club ou une structure de recommander Tennis Impact à leurs joueurs. 
-        En contrepartie, le coach reçoit une <strong>commission sur chaque inscription validée</strong>.
-      </p>
-
-      <h3 style="margin-top:30px; font-size:1.4em;">Vos missions</h3>
-      <ul style="margin:15px 0 30px 20px; line-height:1.6;">
-        <li>Promouvoir les stages et offres de Tennis Impact</li>
-        <li>Recommander des joueurs potentiellement intéressés</li>
-        <li>Respecter notre image de marque</li>
-      </ul>
-
-      <h3 style="font-size:1.4em;">Rémunération</h3>
-      <p style="line-height:1.6;">
-        En tant qu’apporteur, vous percevez :
-        <br><br>
-        <strong>7% du montant HT</strong> la première année, puis :
-        <ul style="margin:10px 0 30px 20px;">
-          <li>5% les 2 années suivantes</li>
-          <li>4% les 2 années suivantes</li>
-          <li>3% les 2 années suivantes</li>
-          <li>2% pendant encore 3 ans</li>
+  <header class="navbar">
+    <div class="navbar__container">
+      <a class="navbar__brand" href="index.html" aria-label="Retour à l'accueil Tennis Impact">
+        <img src="assets/images/logo.svg" alt="Tennis Impact" />
+      </a>
+      <button class="navbar__toggle" id="navToggle" aria-expanded="false" aria-controls="mainNav" aria-label="Ouvrir le menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <nav class="navbar__links" id="mainNav" aria-label="Navigation principale">
+        <ul class="navbar__menu">
+          <li><a href="index.html#stages" class="nav-link">Stages jeunes</a></li>
+          <li><a href="lecon_individuelle.html" class="nav-link">Leçons individuelles</a></li>
+          <li>
+            <a href="espace_coach.html" class="nav-link" aria-current="page">Espace coach</a>
+          </li>
+          <li><a href="index.html#galerie" class="nav-link">Galerie</a></li>
+          <li><a href="reserver.html" class="nav-link">Réserver un stage</a></li>
+          <li><a href="mailto:contact@tennisimpact.fr" class="nav-link nav-link--cta">Contact</a></li>
         </ul>
-        Soit une commission possible sur <strong>10 ans</strong>.
-      </p>
-
-      <h3 style="font-size:1.4em;">Avantages</h3>
-      <ul style="margin:15px 0 30px 20px; line-height:1.6;">
-        <li>Suivi transparent des inscriptions</li>
-        <li>Contrat clair, sans exclusivité</li>
-        <li>Versement rapide après paiement</li>
-      </ul>
-
-      <p style="text-align:center;">
-        📄 <a href="docs/contrat_apporteur_tennis_impact.pdf" style="color:#0c2340; text-decoration:underline;" download>Télécharger le contrat complet</a>
-      </p>
-
-      <div style="text-align:center; margin-top:40px;">
-        <a href="#formulaire-coach" style="padding:15px 30px; font-size:1.1em; background:#c9a33c; color:white; border-radius:40px; text-decoration:none;">Je souhaite devenir partenaire</a>
-      </div>
+      </nav>
     </div>
-  </div>
-</section>
+  </header>
 
-<section id="formulaire-coach" style="background:#0c2340; padding:60px 20px;">
-  <div style="max-width:800px; margin:0 auto; color:white;">
-    <h2 style="text-align:center; margin-bottom:30px;">Formulaire de Contact – Espace Coach</h2>
-    <form id="coachForm" style="display:grid; gap:20px;" onsubmit="event.preventDefault(); alert('Votre demande a bien été envoyée.');">
-      <input type="text" placeholder="Nom / Prénom" required style="padding:15px; border:none; border-radius:8px;">
-      <input type="email" placeholder="Adresse email" required style="padding:15px; border:none; border-radius:8px;">
-      <input type="tel" placeholder="Téléphone" required style="padding:15px; border:none; border-radius:8px;">
-      <textarea placeholder="Expliquez votre démarche ou demande" rows="5" required style="padding:15px; border:none; border-radius:8px;"></textarea>
-      <button type="submit" style="padding:15px; background:#c9a33c; color:white; border:none; border-radius:30px; font-size:1.1em;">Envoyer</button>
-    </form>
-  </div>
-</section>
+  <main>
+    <section class="hero-coach">
+      <div class="container section__grid">
+        <div>
+          <p class="hero__subtitle">Partenariat premium</p>
+          <h1>Devenez coach partenaire Tennis Impact</h1>
+          <p>Rejoignez un réseau d’experts passionnés, accédez à nos infrastructures haut de gamme et bénéficiez d’un accompagnement business sur mesure.</p>
+          <div class="hero__actions">
+            <a class="btn btn--gold" href="#formulaire">Rejoindre le programme</a>
+            <a class="hero__link hero__link--light" href="CONTRAT%20APPORTEUR%20TYPE.pdf" download>
+              Télécharger le contrat
+              <span class="hero__link-icon" aria-hidden="true">↗</span>
+            </a>
+          </div>
+          <div class="benefits-grid">
+            <div class="benefit-card">
+              <h3>Commission jusqu'à 10 ans</h3>
+              <p>Rémunération progressive sur chaque joueur parrainé tout au long de sa progression.</p>
+            </div>
+            <div class="benefit-card">
+              <h3>Accès infrastructures</h3>
+              <p>Réservez nos courts et espaces bien-être pour accueillir vos joueurs dans un cadre prestige.</p>
+            </div>
+            <div class="benefit-card">
+              <h3>Outils marketing clé en main</h3>
+              <p>Kits digitaux, argumentaires commerciaux et reporting hebdomadaire des prospects.</p>
+            </div>
+          </div>
+        </div>
+        <div class="coach-visual">
+          <img src="https://images.unsplash.com/photo-1532339142463-fd0a8979791a?auto=format&fit=crop&w=1200&q=80" alt="Coachs de tennis Tennis Impact" />
+        </div>
+      </div>
+    </section>
 
+    <section class="section content-section" id="missions">
+      <div class="container section__grid">
+        <div class="section__content">
+          <span class="eyebrow">Vos missions</span>
+          <h2>Devenez l’ambassadeur privilégié de nos stages</h2>
+          <p>Vous identifiez les profils adaptés, présentez l’expérience Tennis Impact et assurez un suivi personnalisé avant, pendant et après les programmes.</p>
+          <ul class="feature-list">
+            <li>Accompagner la sélection des stages et le planning annuel.</li>
+            <li>Préparer mentalement et physiquement les joueurs recommandés.</li>
+            <li>Partager des bilans réguliers avec notre cellule performance.</li>
+          </ul>
+        </div>
+        <div class="section__visual">
+          <img src="assets/images/gallery-3.svg" alt="Illustration de coaching Tennis Impact" />
+        </div>
+      </div>
+    </section>
 
-<div style="text-align:center; margin-top:60px;">
-  
-</div>
+    <section class="section section--dark">
+      <div class="container">
+        <div class="section__intro">
+          <span class="eyebrow eyebrow--light">Engagements Tennis Impact</span>
+          <h2>Un partenariat construit sur la confiance</h2>
+          <p>Nous investissons dans votre réussite avec un accompagnement marketing, juridique et sportif.</p>
+        </div>
+        <div class="engagement-grid">
+          <div class="engagement-card">
+            <h3>Suivi business dédié</h3>
+            <p>Tracking hebdomadaire des prospects et conversion assurée par notre équipe admissions.</p>
+          </div>
+          <div class="engagement-card">
+            <h3>Programme de fidélité</h3>
+            <p>Bonus exclusifs sur l’hébergement, invitations VIP et accès aux événements pros.</p>
+          </div>
+          <div class="engagement-card">
+            <h3>Communauté d’experts</h3>
+            <p>Workshops trimestriels, masterclass de préparation mentale et veille technique continue.</p>
+          </div>
+        </div>
+      </div>
+    </section>
 
+    <section class="form-card" id="formulaire">
+      <h2 style="font-family: var(--font-heading); font-size: clamp(2rem, 3vw, 2.6rem); margin-bottom: 0.5rem;">Candidatez en 2 minutes</h2>
+      <p style="color: rgba(255, 255, 255, 0.75); max-width: 520px;">Dites-nous en plus sur votre structure et vos objectifs : notre équipe vous recontacte sous 24h.</p>
+      <form class="form-grid" id="coachForm">
+        <input type="text" name="name" placeholder="Nom &amp; Prénom" required />
+        <input type="email" name="email" placeholder="Email professionnel" required />
+        <input type="tel" name="phone" placeholder="Téléphone" required />
+        <select name="experience" required>
+          <option value="" disabled selected>Expérience coaching</option>
+          <option value="-5">0 - 5 ans</option>
+          <option value="5-10">5 - 10 ans</option>
+          <option value="10+">10 ans et +</option>
+        </select>
+        <input type="text" name="club" placeholder="Club ou structure" required />
+        <textarea name="message" placeholder="Parlez-nous de vos joueurs et de vos attentes" required></textarea>
+        <button class="btn btn--gold" type="submit">Envoyer ma candidature</button>
+      </form>
+    </section>
+  </main>
+
+  <script>
+    const navToggle = document.getElementById('navToggle');
+    const mainNav = document.getElementById('mainNav');
+    const coachForm = document.getElementById('coachForm');
+
+    navToggle?.addEventListener('click', () => {
+      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+      navToggle.setAttribute('aria-expanded', String(!expanded));
+      mainNav.classList.toggle('is-open');
+      document.body.classList.toggle('no-scroll', !expanded);
+    });
+
+    mainNav?.querySelectorAll('a, button').forEach(link => {
+      link.addEventListener('click', () => {
+        if (mainNav.classList.contains('is-open')) {
+          mainNav.classList.remove('is-open');
+          document.body.classList.remove('no-scroll');
+          navToggle?.setAttribute('aria-expanded', 'false');
+        }
+      });
+    });
+
+    coachForm?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      alert('Merci ! Nous vous recontactons très vite.');
+      coachForm.reset();
+    });
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -21,16 +21,20 @@
         <span></span>
         <span></span>
       </button>
-      <nav class="navbar__links" id="mainNav">
-        <a href="#academie" class="nav-link">Notre académie</a>
-        <a href="#stages" class="nav-link">Stages jeunes</a>
-        <a href="#lecons" class="nav-link">Leçons individuelles</a>
-        <a href="#faq" class="nav-link">FAQ</a>
-        <a href="#galerie" class="nav-link">Galerie</a>
-        <div class="navbar__cta">
-          <a class="btn btn--ghost" href="espace_coach.html">Espace coach</a>
-          <button class="btn btn--gold" data-open-contact>Contact</button>
-        </div>
+      <nav class="navbar__links" id="mainNav" aria-label="Navigation principale">
+        <ul class="navbar__menu">
+          <li><a href="#academie" class="nav-link">Notre académie</a></li>
+          <li><a href="#stages" class="nav-link">Stages jeunes</a></li>
+          <li><a href="#lecons" class="nav-link">Leçons individuelles</a></li>
+          <li><a href="#faq" class="nav-link">FAQ</a></li>
+          <li><a href="#galerie" class="nav-link">Galerie</a></li>
+          <li><a href="espace_coach.html" class="nav-link">Espace coach</a></li>
+          <li>
+            <button class="nav-link nav-link--cta" type="button" data-open-contact>
+              Contact
+            </button>
+          </li>
+        </ul>
       </nav>
     </div>
   </header>
@@ -46,7 +50,10 @@
         </p>
         <div class="hero__actions">
           <a class="btn btn--gold" href="reserver.html">Réserver un stage</a>
-          <a class="btn btn--ghost" href="reservation_lecon.html">Planifier une leçon</a>
+          <a class="hero__link hero__link--light" href="reservation_lecon.html">
+            Planifier une leçon privée
+            <span class="hero__link-icon" aria-hidden="true">↗</span>
+          </a>
         </div>
         <div class="hero__badges" data-aos="fade-up" data-aos-delay="200">
           <div class="badge">
@@ -346,7 +353,7 @@
       body.classList.toggle('no-scroll', isOpen);
     });
 
-    nav.querySelectorAll('a').forEach(link => {
+    nav.querySelectorAll('a, button').forEach(link => {
       link.addEventListener('click', () => {
         if (nav.classList.contains('is-open')) {
           closeNav();

--- a/lecon_individuelle.html
+++ b/lecon_individuelle.html
@@ -1,30 +1,316 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta charset="UTF-8">
-  <title>Test Bouton Final</title>
-  <link rel="stylesheet" href="css/style.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Leçons individuelles – Tennis Impact</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      background: #f8f9fc;
+      color: var(--color-navy);
+    }
+
+    .sub-hero {
+      position: relative;
+      padding: 120px 0 80px;
+      background: linear-gradient(rgba(7, 17, 29, 0.82), rgba(7, 17, 29, 0.82)),
+        url('https://images.unsplash.com/photo-1509099836639-18ba1795216d?auto=format&fit=crop&w=1800&q=80') center/cover;
+      color: var(--color-white);
+      text-align: center;
+    }
+
+    .sub-hero h1 {
+      font-family: var(--font-heading);
+      font-size: clamp(2.5rem, 4vw, 3.25rem);
+      margin-bottom: 1rem;
+    }
+
+    .sub-hero p {
+      font-size: 1.1rem;
+      max-width: 680px;
+      margin: 0 auto 2rem;
+    }
+
+    .pillars {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1.5rem;
+      margin-top: 3rem;
+    }
+
+    .pillar-card {
+      background: rgba(255, 255, 255, 0.08);
+      border-radius: var(--radius-card);
+      padding: 1.8rem;
+      backdrop-filter: blur(12px);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+    }
+
+    .pillar-card h3 {
+      font-size: 1.1rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .package-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.8rem;
+      margin-top: 3rem;
+    }
+
+    .package-card {
+      background: var(--color-white);
+      border-radius: var(--radius-card);
+      box-shadow: var(--shadow-soft);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      transition: transform var(--transition-base), box-shadow var(--transition-base);
+    }
+
+    .package-card:hover {
+      transform: translateY(-6px);
+      box-shadow: var(--shadow-strong);
+    }
+
+    .package-card img {
+      width: 100%;
+      height: 200px;
+      object-fit: cover;
+    }
+
+    .package-card .card__body {
+      padding: 1.8rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .package-card .card__price {
+      font-size: 1.2rem;
+      font-weight: 600;
+      color: var(--color-gold-dark);
+    }
+
+    .locations {
+      margin-top: 4.5rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.8rem;
+    }
+
+    .location-card {
+      border-radius: var(--radius-card);
+      background: var(--color-white);
+      box-shadow: var(--shadow-soft);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .location-card img {
+      height: 180px;
+      object-fit: cover;
+    }
+
+    .location-card .card__body {
+      padding: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .cta-banner {
+      margin: 5rem 0 3rem;
+      background: linear-gradient(120deg, rgba(249, 214, 92, 0.95), rgba(217, 166, 0, 0.95));
+      border-radius: var(--radius-large);
+      padding: clamp(2.5rem, 5vw, 4rem);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+      text-align: center;
+      box-shadow: var(--shadow-soft);
+    }
+
+    .cta-banner h2 {
+      font-family: var(--font-heading);
+      color: var(--color-night);
+      font-size: clamp(2rem, 3.2vw, 2.7rem);
+    }
+
+    .cta-banner p {
+      color: rgba(5, 10, 15, 0.75);
+      max-width: 620px;
+    }
+
+    @media (max-width: 768px) {
+      .navbar__links {
+        background: var(--color-night);
+      }
+    }
+  </style>
 </head>
 <body>
-<a href="index.html" style="position: fixed; top: 20px; left: 20px; background-color: #c9a33c; color: white; padding: 12px 20px; font-size: 0.95em; border-radius: 30px; text-decoration: none; z-index: 999999; box-shadow: 0 4px 10px rgba(0,0,0,0.15); transition: background 0.3s ease;">← Retour à l’accueil</a>
-
-<header class="header">
-  <div class="container">
-    <div class="logo">
-      <img src="images/logo-tennis-impact-blanc.png" alt="Logo Tennis Impact">
+  <header class="navbar">
+    <div class="navbar__container">
+      <a class="navbar__brand" href="index.html" aria-label="Retour à l'accueil Tennis Impact">
+        <img src="assets/images/logo.svg" alt="Tennis Impact" />
+      </a>
+      <button class="navbar__toggle" id="navToggle" aria-expanded="false" aria-controls="mainNav" aria-label="Ouvrir le menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <nav class="navbar__links" id="mainNav" aria-label="Navigation principale">
+        <ul class="navbar__menu">
+          <li><a href="index.html#stages" class="nav-link">Stages jeunes</a></li>
+          <li>
+            <a href="lecon_individuelle.html" class="nav-link" aria-current="page">Leçons individuelles</a>
+          </li>
+          <li><a href="espace_coach.html" class="nav-link">Espace coach</a></li>
+          <li><a href="index.html#faq" class="nav-link">FAQ</a></li>
+          <li><a href="reserver.html" class="nav-link">Réserver un stage</a></li>
+          <li><a href="mailto:contact@tennisimpact.fr" class="nav-link nav-link--cta">Contact</a></li>
+        </ul>
+      </nav>
     </div>
-    <nav class="nav">
-      <ul>
-        <li><a href="index.html">Accueil</a></li>
-        <li><a href="#stages">Nos Stages</a></li>
-        <li><a href="#lecon">Leçon Individuelle</a></li>
-        <li><a href="#coach">Espace Coach</a></li>
-      </ul>
-    </nav>
-  </div>
-</header>
+  </header>
 
+  <main>
+    <section class="sub-hero">
+      <div class="container">
+        <p class="hero__subtitle">Coaching individuel premium</p>
+        <h1>Une progression accélérée avec un coach dédié</h1>
+        <p>
+          Chaque séance est construite sur-mesure en fonction de votre objectif : reprise du jeu, préparation d’un tournoi ou optimisation technique.
+          Nos coachs certifiés vous accompagnent dans le moindre détail.
+        </p>
+        <div class="hero__actions">
+          <a class="btn btn--gold" href="reservation_lecon.html">Réserver une leçon</a>
+          <a class="hero__link hero__link--light" href="#programme">
+            Découvrir le programme
+            <span class="hero__link-icon" aria-hidden="true">↗</span>
+          </a>
+        </div>
+        <div class="pillars">
+          <div class="pillar-card">
+            <h3>Bilan technique filmé</h3>
+            <p>Analyse vidéo HD et plan d’actions prioritaire remis sous 48h.</p>
+          </div>
+          <div class="pillar-card">
+            <h3>Préparation mentale</h3>
+            <p>Routines et protocoles sur-mesure pour gagner en confiance.</p>
+          </div>
+          <div class="pillar-card">
+            <h3>Accompagnement physique</h3>
+            <p>Travail spécifique sur la mobilité, les appuis et la vitesse d’exécution.</p>
+          </div>
+        </div>
+      </div>
+    </section>
 
+    <section class="section" id="programme">
+      <div class="container">
+        <span class="eyebrow">Formules 100% personnalisées</span>
+        <h2>Choisissez le format adapté à votre rythme</h2>
+        <div class="package-grid">
+          <article class="package-card">
+            <img src="assets/images/lecon-1.svg" alt="Session découverte" />
+            <div class="card__body">
+              <h3>Session découverte</h3>
+              <p class="card__price">45€ • 1h</p>
+              <p>Diagnostic complet et priorisation des axes de progression avec votre coach référent.</p>
+              <a class="btn btn--outline" href="reservation_lecon.html">Planifier</a>
+            </div>
+          </article>
+          <article class="package-card">
+            <img src="assets/images/lecon-2.svg" alt="Pack intensif 5h" />
+            <div class="card__body">
+              <h3>Pack intensif 5h</h3>
+              <p class="card__price">200€ • 5x1h</p>
+              <p>Progression rapide avec feedback vidéo, objectifs hebdomadaires et suivi précis.</p>
+              <a class="btn btn--outline" href="reservation_lecon.html">Planifier</a>
+            </div>
+          </article>
+          <article class="package-card">
+            <img src="assets/images/lecon-3.svg" alt="Pack performance" />
+            <div class="card__body">
+              <h3>Pack performance 10h</h3>
+              <p class="card__price">380€ • 10x1h</p>
+              <p>Coaching global : plan annuel, préparation mentale, accompagnement sur tournoi.</p>
+              <a class="btn btn--outline" href="reservation_lecon.html">Planifier</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
 
+    <section class="section section--dark">
+      <div class="container">
+        <div class="section__intro" data-aos="fade-up">
+          <span class="eyebrow eyebrow--light">Vos lieux d’entraînement</span>
+          <h2>Des sites d’exception à Paris et Colmar</h2>
+          <p>Choisissez votre terrain de jeu : ambiance légendaire à Paris ou écrin naturel en Alsace.</p>
+        </div>
+        <div class="locations">
+          <article class="location-card">
+            <img src="https://images.unsplash.com/photo-1505678261036-a3fcc5e884ee?auto=format&fit=crop&w=1200&q=80" alt="Court de tennis à Paris" />
+            <div class="card__body">
+              <h3>Paris • Stade prestige</h3>
+              <p>Courts en terre battue inspirés de Roland-Garros, club-house premium et espaces bien-être.</p>
+              <p><strong>Disponibilités :</strong> 7j/7 de 7h à 22h.</p>
+            </div>
+          </article>
+          <article class="location-card">
+            <img src="https://images.unsplash.com/photo-1516483638261-f4dbaf036963?auto=format&fit=crop&w=1200&q=80" alt="Complexe de tennis à Colmar" />
+            <div class="card__body">
+              <h3>Colmar • Centre Tennis Europe</h3>
+              <p>Complexe couvert &amp; outdoor entouré de nature pour travailler technicité et relâchement.</p>
+              <p><strong>Disponibilités :</strong> Du lundi au samedi de 8h à 20h.</p>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
 
+    <section class="container cta-banner">
+      <h2>Passez au niveau supérieur dès cette semaine</h2>
+      <p>Réservez votre première séance en choisissant Paris ou Colmar et nous vous rappelons sous 24h pour finaliser les détails logistiques.</p>
+      <div class="hero__actions">
+        <a class="btn btn--gold" href="reservation_lecon.html">Je réserve ma leçon</a>
+        <a class="hero__link" href="mailto:contact@tennisimpact.fr">
+          Parler à un coach
+          <span class="hero__link-icon" aria-hidden="true">↗</span>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const navToggle = document.getElementById('navToggle');
+    const mainNav = document.getElementById('mainNav');
+
+    navToggle?.addEventListener('click', () => {
+      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+      navToggle.setAttribute('aria-expanded', String(!expanded));
+      mainNav.classList.toggle('is-open');
+      document.body.classList.toggle('no-scroll', !expanded);
+    });
+
+    mainNav?.querySelectorAll('a, button').forEach(link => {
+      link.addEventListener('click', () => {
+        if (mainNav.classList.contains('is-open')) {
+          mainNav.classList.remove('is-open');
+          document.body.classList.remove('no-scroll');
+          navToggle?.setAttribute('aria-expanded', 'false');
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/reservation_lecon.html
+++ b/reservation_lecon.html
@@ -1,88 +1,220 @@
 <!DOCTYPE html>
-
 <html lang="fr">
 <head>
-<meta charset="utf-8"/>
-<title>Réservation Leçon Individuelle – Tennis Impact</title>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<style>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Réservation leçon individuelle – Tennis Impact</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
     body {
       font-family: 'Poppins', sans-serif;
-      background: #fff;
-      padding: 40px 20px;
+      background: #f8f9fc;
       color: #001f3f;
+      margin: 0;
     }
-    form {
-      max-width: 600px;
-      margin: 0 auto;
-      background: #f0f0f0;
-      padding: 30px;
-      border-radius: 12px;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
-    label {
-      display: block;
-      margin-top: 20px;
-      font-weight: 600;
-    }
-    input, select {
-      width: 100%;
-      padding: 10px;
-      border-radius: 6px;
-      border: 1px solid #ccc;
-      margin-top: 8px;
-    }
-    button {
-      margin-top: 30px;
-      background: #001f3f;
+
+    .booking-hero {
+      position: relative;
+      padding: 110px 0 80px;
+      background: linear-gradient(120deg, rgba(5, 10, 15, 0.82), rgba(13, 27, 42, 0.82)),
+        url('https://images.unsplash.com/photo-1532339142463-fd0a8979791a?auto=format&fit=crop&w=1800&q=80') center/cover;
       color: #fff;
-      border: none;
-      padding: 12px 20px;
-      font-weight: bold;
-      border-radius: 8px;
-      cursor: pointer;
+      text-align: center;
+    }
+
+    .booking-hero h1 {
+      font-family: 'Playfair Display', serif;
+      font-size: clamp(2.4rem, 4vw, 3.1rem);
+      margin-bottom: 1rem;
+    }
+
+    .booking-hero p {
+      max-width: 640px;
+      margin: 0 auto 2rem;
+      font-size: 1.1rem;
+    }
+
+    .reservation-card {
+      max-width: 720px;
+      margin: -60px auto 60px;
+      background: #fff;
+      border-radius: 24px;
+      box-shadow: 0 30px 80px rgba(5, 10, 15, 0.18);
+      padding: clamp(2.5rem, 4vw, 3.5rem);
+    }
+
+    .reservation-card h2 {
+      font-family: 'Playfair Display', serif;
+      margin-bottom: 1.5rem;
+    }
+
+    .reservation-card form {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .reservation-card label {
+      font-weight: 600;
+      display: block;
+    }
+
+    .reservation-card input,
+    .reservation-card select,
+    .reservation-card textarea {
+      width: 100%;
+      padding: 0.9rem 1rem;
+      border-radius: 12px;
+      border: 1px solid rgba(13, 27, 42, 0.15);
+      font-size: 0.95rem;
+      background: rgba(248, 249, 252, 0.9);
+    }
+
+    .reservation-card textarea {
+      min-height: 120px;
+      resize: vertical;
+    }
+
+    .reservation-card .form-row {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+    }
+
+    .reservation-card button {
+      margin-top: 1.5rem;
+      align-self: start;
+    }
+
+    .info-banner {
+      max-width: 720px;
+      margin: 0 auto 80px;
+      text-align: center;
+      color: rgba(13, 27, 42, 0.7);
     }
   </style>
 </head>
 <body>
+  <header class="navbar">
+    <div class="navbar__container">
+      <a class="navbar__brand" href="index.html" aria-label="Retour à l'accueil Tennis Impact">
+        <img src="assets/images/logo.svg" alt="Tennis Impact" />
+      </a>
+      <button class="navbar__toggle" id="navToggle" aria-expanded="false" aria-controls="mainNav" aria-label="Ouvrir le menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <nav class="navbar__links" id="mainNav" aria-label="Navigation principale">
+        <ul class="navbar__menu">
+          <li><a href="stages_jeunes.html" class="nav-link">Stages jeunes</a></li>
+          <li><a href="lecon_individuelle.html" class="nav-link">Leçons individuelles</a></li>
+          <li><a href="espace_coach.html" class="nav-link">Espace coach</a></li>
+          <li><a href="reserver.html" class="nav-link">Réserver un stage</a></li>
+          <li><a href="mailto:contact@tennisimpact.fr" class="nav-link nav-link--cta">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
 
-<div style="position: absolute; top: 20px; left: 20px; z-index: 9999;">
-  <a href="index.html" class="btn-retour" style="padding: 10px 20px; background-color: #FFD700; color: black; font-weight: bold; border-radius: 5px; text-decoration: none;">← Retour à l'accueil</a>
-</div>
+  <section class="booking-hero">
+    <div class="container">
+      <p class="hero__subtitle">Coaching individuel premium</p>
+      <h1>Réservez votre leçon privée</h1>
+      <p>Sélectionnez votre coach et votre ville préférée – Paris ou Colmar – puis choisissez la date idéale. Notre équipe vous confirme la séance sous 12h.</p>
+      <div class="hero__actions">
+        <a class="btn btn--gold" href="#formulaire">Planifier maintenant</a>
+        <a class="hero__link hero__link--light" href="mailto:contact@tennisimpact.fr">
+          Parler à un coach
+          <span class="hero__link-icon" aria-hidden="true">↗</span>
+        </a>
+      </div>
+    </div>
+  </section>
 
-<section style="position: relative; width: 100%; height: 380px; background: url('assets/photos/2.png') center/cover no-repeat; display: flex; align-items: center; justify-content: center;">
-<div style="background-color: rgba(0,0,0,0.55); padding: 40px; border-radius: 12px; color: white; text-align: center;">
-<h1 style="font-size: 2.5rem; margin: 0;">Réservez votre leçon</h1>
-<h2 style="font-size: 1.6rem; font-weight: 300;">Un coaching individuel avec nos meilleurs entraîneurs</h2>
-<p style="margin-top: 10px; font-size: 1rem;">Académie Tennis Impact</p>
-</div>
-</section>
+  <main class="reservation-card" id="formulaire">
+    <h2>Informations de réservation</h2>
+    <form id="lessonForm">
+      <div class="form-row">
+        <div>
+          <label for="fullName">Nom complet</label>
+          <input id="fullName" name="fullName" type="text" required />
+        </div>
+        <div>
+          <label for="email">Email</label>
+          <input id="email" name="email" type="email" required />
+        </div>
+      </div>
+      <div class="form-row">
+        <div>
+          <label for="date">Date souhaitée</label>
+          <input id="date" name="date" type="date" required />
+        </div>
+        <div>
+          <label for="time">Heure souhaitée</label>
+          <input id="time" name="time" type="time" required />
+        </div>
+      </div>
+      <div class="form-row">
+        <div>
+          <label for="location">Lieu de la leçon</label>
+          <select id="location" name="location" required>
+            <option value="" disabled selected>Choisissez votre site</option>
+            <option value="paris">Paris – Stade prestige</option>
+            <option value="colmar">Colmar – Centre Tennis Europe</option>
+          </select>
+        </div>
+        <div>
+          <label for="level">Niveau de jeu</label>
+          <select id="level" name="level" required>
+            <option value="" disabled selected>Sélectionnez</option>
+            <option value="debutant">Débutant</option>
+            <option value="intermediaire">Intermédiaire</option>
+            <option value="avance">Avancé / Compétition</option>
+          </select>
+        </div>
+      </div>
+      <div>
+        <label for="details">Objectifs &amp; besoins</label>
+        <textarea id="details" name="details" placeholder="Décrivez vos axes de progression, préférences de coach, besoins spécifiques"></textarea>
+      </div>
+      <button class="btn btn--gold" id="pay-btn" type="submit">Valider ma demande</button>
+    </form>
+  </main>
 
-<h1>Réservez votre leçon individuelle</h1>
-<form>
-<label>Nom complet</label>
-<input required="" type="text"/>
-<label>Date souhaitée</label>
-<input required="" type="date"/>
-<label>Heure souhaitée</label>
-<input required="" type="time"/>
-<label>Niveau de jeu</label>
-<select required="">
-<option>Débutant</option>
-<option>Intermédiaire</option>
-<option>Avancé</option>
-</select>
-<button id="pay-btn" style="margin-top: 30px;">Valider et Payer</button>
+  <div class="info-banner">
+    <p>Après validation, un coach Tennis Impact vous contacte pour confirmer le créneau et finaliser le paiement sécurisé.</p>
+  </div>
 
+  <script>
+    const navToggle = document.getElementById('navToggle');
+    const mainNav = document.getElementById('mainNav');
+    const lessonForm = document.getElementById('lessonForm');
 
-</form>
+    navToggle?.addEventListener('click', () => {
+      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+      navToggle.setAttribute('aria-expanded', String(!expanded));
+      mainNav.classList.toggle('is-open');
+      document.body.classList.toggle('no-scroll', !expanded);
+    });
 
-<script src="https://js.stripe.com/v3/"></script>
-<script src="elements.js"></script>
+    mainNav?.querySelectorAll('a, button').forEach(link => {
+      link.addEventListener('click', () => {
+        if (mainNav.classList.contains('is-open')) {
+          mainNav.classList.remove('is-open');
+          document.body.classList.remove('no-scroll');
+          navToggle?.setAttribute('aria-expanded', 'false');
+        }
+      });
+    });
 
-<div style="text-align:center; margin-top: 40px;">
-  <a href="index.html" class="btn-retour" style="padding: 10px 20px; background-color: #FFD700; color: black; font-weight: bold; border-radius: 5px; text-decoration: none;">← Retour à l'accueil</a>
-</div>
-
+    lessonForm?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      alert('Merci ! Votre coach Tennis Impact vous contactera sous 12h.');
+      lessonForm.reset();
+    });
+  </script>
 </body>
 </html>

--- a/reserver.html
+++ b/reserver.html
@@ -1,1281 +1,328 @@
-
 <!DOCTYPE html>
-
 <html lang="fr">
 <head>
-<meta charset="utf-8"/>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Réserver un Stage - Tennis Impact</title>
-<link href="style.css" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Playfair+Display&amp;family=Poppins:wght@300;400;600&amp;display=swap" rel="stylesheet"/>
-<style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Réserver un stage – Tennis Impact</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
     body {
-      font-family: 'Poppins', sans-serif;
-      background-color: #0d0d1f;
-      color: #fff;
-      margin: 0;
-      padding: 0;
+      background: #f7f8fc;
+      color: var(--color-navy);
     }
-    .container {
-  display: grid;
-  grid-template-columns: 2fr 1fr;
-  align-items: start;
-  gap: 40px;
-  min-height: 100vh;
 
-    .stage-card {
-      background: white;
-      color: black;
-      border-radius: 20px;
+    .booking-hero {
+      position: relative;
+      padding: 120px 0 80px;
+      background: linear-gradient(120deg, rgba(5, 10, 15, 0.82), rgba(13, 27, 42, 0.82)),
+        url('https://images.unsplash.com/photo-1524222717473-730000096953?auto=format&fit=crop&w=1800&q=80') center/cover;
+      color: var(--color-white);
+      text-align: center;
+    }
+
+    .booking-hero h1 {
+      font-family: var(--font-heading);
+      font-size: clamp(2.6rem, 4vw, 3.4rem);
+      margin-bottom: 1rem;
+    }
+
+    .booking-hero p {
+      max-width: 720px;
+      margin: 0 auto 2rem;
+      font-size: 1.1rem;
+    }
+
+    .stage-options {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+      margin-top: 3rem;
+    }
+
+    .option-card {
+      background: var(--color-white);
+      border-radius: var(--radius-card);
+      box-shadow: var(--shadow-soft);
+      padding: 1.8rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.9rem;
+      border-top: 6px solid transparent;
+      transition: transform var(--transition-base), box-shadow var(--transition-base);
+    }
+
+    .option-card:hover {
+      transform: translateY(-6px);
+      box-shadow: var(--shadow-strong);
+      border-top-color: var(--color-gold);
+    }
+
+    .option-card h3 {
+      font-family: var(--font-heading);
+      font-size: 1.4rem;
+    }
+
+    .option-card ul {
+      list-style: disc;
+      padding-left: 1.2rem;
+      color: var(--color-grey-600);
+      line-height: 1.5;
+    }
+
+    .locations-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+      margin-top: 3rem;
+    }
+
+    .location-tile {
+      background: var(--color-white);
+      border-radius: var(--radius-card);
       overflow: hidden;
-      box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-      margin-bottom: 30px;
-      max-width: 500px;
+      box-shadow: var(--shadow-soft);
+      display: flex;
+      flex-direction: column;
     }
-    .stage-card img {
+
+    .location-tile img {
+      height: 200px;
+      object-fit: cover;
+    }
+
+    .location-tile .card__body {
+      padding: 1.6rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+    }
+
+    .booking-form {
+      margin-top: 4rem;
+      background: var(--color-white);
+      border-radius: var(--radius-large);
+      box-shadow: var(--shadow-soft);
+      padding: clamp(2.5rem, 5vw, 4rem);
+    }
+
+    .booking-form form {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+      margin-top: 2rem;
+    }
+
+    .booking-form input,
+    .booking-form select,
+    .booking-form textarea {
       width: 100%;
-      height: auto;
-    }
-    .stage-card .content {
-      padding: 20px;
-    }
-    .stage-card h3 {
-      font-family: 'Playfair Display', serif;
-      margin-top: 0;
-      color: #0d0d1f;
-    }
-    .stage-card .price {
-      font-weight: bold;
-      color: #b28d00;
-    }
-    .stage-card ul {
-      padding-left: 20px;
-    }
-    .stage-card button {
-      background-color: #0d0d1f;
-      color: white;
-      border: none;
-      padding: 12px 20px;
-      border-radius: 10px;
-      cursor: pointer;
-      margin-top: 15px;
-    }
-    .cart {
-  position: -webkit-sticky;
-  position: sticky;
-  top: 40px;
-  align-self: start;
-  background: #1a1a2e;
-  border-radius: 20px;
-  padding: 30px;
-  box-shadow: 0 4px 20px rgba(255, 215, 0, 0.2);
-  min-width: 300px;
-  color: white;
-}
-    .cart h2 {
-      color: #fdd835;
-      font-family: 'Playfair Display', serif;
-    }
-    .cart-item {
-      background: #111;
-      margin-bottom: 15px;
-      padding: 15px;
-      border-radius: 10px;
-    }
-    .cart-item span {
-      display: block;
-    }
-    .cart button {
-      width: 100%;
-      background-color: #fdd835;
-      color: #0d0d1f;
-      font-weight: bold;
-      padding: 15px;
-      border: none;
+      padding: 0.95rem 1.1rem;
+      border: 1px solid rgba(13, 27, 42, 0.12);
       border-radius: 12px;
-      cursor: pointer;
-      margin-top: 20px;
+      font-size: 0.95rem;
+      background: rgba(255, 255, 255, 0.96);
     }
-  
-.premium-form {
-  background: #ffffff;
-  border: 2px solid #fdd835;
-  box-shadow: 0 0 40px rgba(255, 215, 0, 0.25);
-  border-radius: 20px;
-  padding: 40px;
-  font-family: 'Poppins', sans-serif;
-  color: #0d0d1f;
-}
-.premium-form h2 {
-  font-family: 'Playfair Display', serif;
-  font-size: 28px;
-  color: #0d0d1f;
-}
-.premium-form input,
-.premium-form select {
-  width: 100%;
-  margin-bottom: 15px;
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px solid #ccc;
-}
-.premium-form button[type='submit'] {
-  background-color: #0d0d1f;
-  color: #fdd835;
-  font-weight: bold;
-  padding: 12px 20px;
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-}
-.premium-form button[type='button'] {
-  background-color: #bbb;
-  color: white;
-  margin-left: 10px;
-  padding: 12px 20px;
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-}
 
+    .booking-form textarea {
+      min-height: 140px;
+      grid-column: 1 / -1;
+      resize: vertical;
+    }
 
-.stages {
-  padding-right: 20px;
-  border-right: 1px solid rgba(255, 255, 255, 0.1);
-}
-.cart {
-  padding-left: 30px;
-  background: #12122a;
-}
+    .booking-form button {
+      grid-column: 1 / -1;
+      justify-self: start;
+    }
 
-
-@keyframes fadeZoomIn {
-  0% { opacity: 0; transform: scale(0.8) translate(-50%, -50%); }
-  100% { opacity: 1; transform: scale(1) translate(-50%, -50%); }
-}
-#form-popup {
-  animation: fadeZoomIn 0.4s ease-out;
-}
-
-
-.stage-card {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  background: white;
-  color: black;
-  border-radius: 20px;
-  overflow: hidden;
-  box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-  margin-bottom: 30px;
-  max-width: 100%;
-}
-.stage-card img {
-  width: 300px;
-  height: auto;
-  object-fit: cover;
-}
-.stage-card .content {
-  padding: 20px;
-  flex: 1;
-}
-
-</style>
-<script>
-function openForm(stageName) {
-  const popup = document.getElementById("form-popup");
-  const input = popup.querySelector("input[name='stage'], select[name='stage']");
-  if (input) input.value = stageName;
-  popup.style.display = "block";
-}
-
-function closeForm() {
-  document.getElementById("form-popup").style.display = "none";
-}
-
-// Simulation d'envoi avec fermeture automatique
-document.addEventListener("DOMContentLoaded", function () {
-  const form = document.querySelector("#form-popup form");
-  if (form) {
-    form.addEventListener("submit", function (e) {
-      e.preventDefault();
-      console.log("Formulaire soumis. Simulation EmailJS.");
-      // Remplace ce bloc par EmailJS.send(...) plus tard
-      setTimeout(() => {
-        alert("Formulaire envoyé !");
-        closeForm();
-      }, 1000);
-    });
-  }
-});
-</script>
-
-<style>
-.popup {
-  display: none;
-  position: fixed;
-  z-index: 9999;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  background: rgba(0,0,0,0.7);
-  overflow-y: auto;
-}
-.popup-content {
-  background: #fff;
-  margin: 5% auto;
-  padding: 30px;
-  border-radius: 16px;
-  max-width: 800px;
-  position: relative;
-  font-family: 'Poppins', sans-serif;
-  box-shadow: 0 0 20px rgba(0,0,0,0.4);
-}
-.popup-content h2 {
-  margin-top: 0;
-  font-size: 1.8em;
-  text-align: center;
-  border-bottom: 1px solid #ddd;
-  padding-bottom: 10px;
-}
-.popup-images img {
-  width: 100%;
-  border-radius: 12px;
-  margin-bottom: 15px;
-  max-height: 300px;
-  object-fit: cover;
-}
-.popup-text {
-  font-size: 1em;
-  color: #222;
-  line-height: 1.6;
-}
-.popup-text ul {
-  padding-left: 20px;
-  list-style-type: disc;
-}
-.popup .close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 28px;
-  color: #555;
-  cursor: pointer;
-}
-</style>
-
-<style>
-html{scroll-behavior:smooth}
-#nos-hebergements, section#nos-hebergements, [id="nos-hebergements"]{scroll-margin-top:120px}
-</style><style>
-html{scroll-behavior:smooth}
-#nos-hebergements,[id="nos-hebergements"],section#nos-hebergements{scroll-margin-top:120px}
-</style><style>html{scroll-behavior:smooth} [id="nos-hebergements"]{scroll-margin-top:120px}</style><style>
-html{scroll-behavior:smooth}
-#nos-hebergements,[id="nos-hebergements"],section#nos-hebergements,h1[id="nos-hebergements"],h2[id="nos-hebergements"]{scroll-margin-top:var(--header-offset,140px)}
-/* also for the nearest heading after the anchor */
-#nos-hebergements + h1, #nos-hebergements + h2 {scroll-margin-top:var(--header-offset,140px)}
-</style></head>
+    .contact-banner {
+      margin: 5rem 0 3rem;
+      text-align: center;
+    }
+  </style>
+</head>
 <body>
-<section style="position: relative; width: 100%; height: 100vh; background: url('assets/photos/3.png') center/cover no-repeat; display: flex; align-items: center; justify-content: center;">
-<div style="background-color: rgba(0,0,0,0.55); padding: 40px; border-radius: 12px; color: white; text-align: center;">
-<h1 style="font-size: 2.5rem; margin: 0;">Réservez votre stage</h1>
-<span id="nos-hebergements"></span><span id="options"></span><h2 style="font-size: 1.6rem; font-weight: 300;">Choisissez vos dates et options d’hébergement</h2>
-<p style="margin-top: 10px; font-size: 1rem;">Académie Tennis Impact</p>
-</div>
-</section>
-<nav style="position: sticky; top: 0; z-index: 1000; background: white; border-bottom: 2px solid #eee; padding: 12px 20px; display: flex; justify-content: center; gap: 30px; font-weight: bold;">
-<a href="#stages" style="color: #001f3f; text-decoration: none;">Stages</a>
-<a href="#methodologie" style="color: #001f3f; text-decoration: none;">Méthodologie</a>
-<a href="reserver.html#nos-hebergements" style="color: #001f3f; text-decoration: none;">Nos Hébergements</a>
-<a href="#options" style="color: #001f3f; text-decoration: none;">Options</a>
-<a href="#faq" style="color: #001f3f; text-decoration: none;">FAQ</a>
-</nav>
-<section style="width: 100%; background-color: white; padding: 100px 20px 120px; position: relative;">
-<div style="max-width: 1000px; margin: auto; text-align: center;">
-<span id="stages"></span><h2 style="color: #001f3f; font-size: 2.5rem; margin-bottom: 20px;">
-      Des stages tennis jeunes au cœur de la Côte d’Azur
-    </h2>
-<h3 style="color: #FFD700; font-size: 1.6rem; font-weight: bold; margin-bottom: 30px;">
-      OFFREZ À VOTRE ENFANT L’EXCELLENCE TENNIS IMPACT
-    </h3>
-<p style="font-size: 1.2rem; color: #333; line-height: 1.8;">
-      Chaque année, Tennis Impact accueille de nombreux jeunes joueurs venus de toute la France pour vivre une expérience unique alliant sport de haut niveau, développement personnel et plaisir du jeu.<br/><br/>
-      Nos stages de tennis pour jeunes sont conçus pour s’adapter à tous les profils : du joueur loisir au compétiteur ambitieux. Dans un environnement structuré, dynamique et bienveillant, votre enfant progresse à son rythme tout en découvrant les exigences du haut niveau.
-    </p>
-</div>
-<!-- Vague de séparation corrigée -->
-<div style="position: absolute; bottom: 0; left: 0; width: 100%; overflow: hidden; line-height: 0;">
-<svg preserveaspectratio="none" style="display: block; width: 100%; height: 70px;" viewbox="0 0 500 50">
-<path d="M0,30 C150,80 350,-10 500,30 L500,00 L0,0 Z" style="fill:#001f3f;"></path>
-</svg>
-</div>
-</section>
-<div class="container">
-<div class="stages">
-<div class="stage-card">
-<img alt="Stage INTENSIF" src="assets/photos/1.png"/>
-<div class="content">
-<h3>Stage INTENSIF</h3>
-<p>Journée entière • 23 juin - 28 juin</p>
-<p class="price">1 600,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>2 sessions de tennis en groupe par jour</li><li>3h d'activité physique</li><li>Rapport individuel</li><li>Repas du midi</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage COMPÉTITION" src="assets/photos/2.png"/>
-<div class="content">
-<h3>Stage COMPÉTITION</h3>
-<p>Journée entière • 23 juin - 05 juil.</p>
-<p class="price">4 200,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>2 sessions de tennis</li><li>Tournoi UTR inclus</li><li>Préparation mentale</li><li>Rapport individuel</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage DEMI-JOURNÉE" src="assets/photos/3.png"/>
-<div class="content">
-<h3>Stage DEMI-JOURNÉE</h3>
-<p>Demi journée • 23 juin - 28 juin</p>
-<p class="price">1 050,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>1 session de tennis</li><li>Rapport individuel</li><li>Matinée uniquement</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage INTENSIF + Français" src="assets/photos/4.png"/>
-<div class="content">
-<h3>Stage INTENSIF + Français</h3>
-<p>Journée entière • 30 juin - 05 juil.</p>
-<p class="price">1 750,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>Tennis + Français</li><li>1h30 de physique/jour</li><li>Repas du midi</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage TENNIS &amp; GOLF" src="assets/photos/5.png"/>
-<div class="content">
-<h3>Stage TENNIS &amp; GOLF</h3>
-<p>Journée entière • 30 juin - 05 juil.</p>
-<p class="price">1 700,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>Tennis le matin</li><li>Golf l’après-midi</li><li>Repas du midi</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage NIGHT SESSIONS" src="assets/photos/6.png"/>
-<div class="content">
-<h3>Stage NIGHT SESSIONS</h3>
-<p>Soir • 30 juin - 04 juil.</p>
-<p class="price">900,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>Sessions du soir</li><li>Cardio tennis</li><li>Welcome pack</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-</div>
-<div class="cart">
-<h2>Mon Panier</h2>
-<div class="cart-item">
-<span><strong>Stage INTENSIF</strong></span>
-<span>23 juin - 28 juin</span>
-<span>1 600,00 €</span>
-</div>
-<button onclick="openForm('Panier')">Valider l’inscription</button>
-</div>
-</div>
-<div id="form-popup" style="display: none; position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; padding: 40px; border-radius: 20px; z-index: 1000; max-width: 800px; width: 90%; max-height: 90vh; overflow-y: auto; font-family: Poppins, sans-serif;">
-<div style="display: flex; justify-content: space-between; align-items: center;">
-<h2 style="margin-top: 0; color: #0d0d1f;">Inscription au Stage</h2>
-<button onclick="closeForm()" style="background-color: #bbb; padding: 5px 10px; border: none; border-radius: 8px;">X</button>
-</div>
-<form>
-<div class="form-grid">
-<label for="lieu">
-     Lieu du stage
-    </label>
-<select id="lieu" name="lieu">
-<option value="Paris">
-      Paris
-     </option>
-<option value="Colmar">
-      Colmar
-     </option>
-</select>
-<label for="type_stage">
-     Type de stage
-    </label>
-<select id="type_stage" name="type_stage">
-<option value="Intensif">
-      Intensif
-     </option>
-<option value="Demi-journée">
-      Demi-journée
-     </option>
-<option value="Compétition">
-      Compétition
-     </option>
-</select>
-<div class="form-field">
-<label for="prenom">
-      Prénom
-     </label>
-</div>
-<div class="form-field">
-<input id="prenom" name="prenom" required="" type="text"/>
-</div>
-<div class="form-field">
-<label for="nom">
-      Nom
-     </label>
-</div>
-<div class="form-field">
-<input id="nom" name="nom" required="" type="text"/>
-</div>
-<div class="form-field">
-<label for="niveau">
-      Niveau FFT
-     </label>
-</div>
-<div class="form-field">
-<select id="niveau" name="niveau">
-<option value="">
-       -- Sélectionnez --
-      </option>
-<option>
-       Blanc
-      </option>
-<option>
-       Violet
-      </option>
-<option>
-       Rouge
-      </option>
-<option>
-       Orange
-      </option>
-<option>
-       Vert
-      </option>
-<option>
-       Jaune
-      </option>
-<option>
-       40
-      </option>
-<option>
-       30/5
-      </option>
-<option>
-       30/4
-      </option>
-<option>
-       30/3
-      </option>
-<option>
-       30/2
-      </option>
-<option>
-       30/1
-      </option>
-<option>
-       30
-      </option>
-<option>
-       15/5
-      </option>
-<option>
-       15/4
-      </option>
-<option>
-       15/3
-      </option>
-<option>
-       15/2
-      </option>
-<option>
-       15/1
-      </option>
-<option>
-       15
-      </option>
-<option>
-       -2/6
-      </option>
-<option>
-       -4/6
-      </option>
-<option>
-       -15
-      </option>
-</select>
-</div>
-<div class="form-field">
-<label for="date">
-      Semaine de Stage
-     </label>
-</div>
-<div class="form-field">
-<input id="date" name="date" required="" type="week"/>
-</div>
-<div class="form-field">
-<label for="hebergement">
-      Souhaitez-vous l’hébergement ?
-     </label>
-</div>
-<div class="form-field">
-<select id="nos-hebergements" name="hebergement">
-<option value="">
-       -- Sélectionnez --
-      </option>
-<option>
-       Oui
-      </option>
-<option>
-       Non
-      </option>
-</select>
-</div>
-</div>
-<button type="submit">
-    Valider l'inscription
-   </button>
-</form>
-</div>
-<script>
-function openForm(stageName) {
-  const popup = document.getElementById("form-popup");
-  const input = popup.querySelector("input[name='stage'], select[name='stage']");
-  if (input) input.value = stageName;
-  popup.style.display = "block";
-}
+  <header class="navbar">
+    <div class="navbar__container">
+      <a class="navbar__brand" href="index.html" aria-label="Retour à l'accueil Tennis Impact">
+        <img src="assets/images/logo.svg" alt="Tennis Impact" />
+      </a>
+      <button class="navbar__toggle" id="navToggle" aria-expanded="false" aria-controls="mainNav" aria-label="Ouvrir le menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <nav class="navbar__links" id="mainNav" aria-label="Navigation principale">
+        <ul class="navbar__menu">
+          <li><a href="stages_jeunes.html" class="nav-link">Stages jeunes</a></li>
+          <li><a href="lecon_individuelle.html" class="nav-link">Leçons individuelles</a></li>
+          <li><a href="espace_coach.html" class="nav-link">Espace coach</a></li>
+          <li><a href="index.html#faq" class="nav-link">FAQ</a></li>
+          <li><a href="reservation_lecon.html" class="nav-link">Réserver une leçon</a></li>
+          <li><a href="mailto:contact@tennisimpact.fr" class="nav-link nav-link--cta">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
 
-function closeForm() {
-  document.getElementById("form-popup").style.display = "none";
-}
+  <main>
+    <section class="booking-hero">
+      <div class="container">
+        <p class="hero__subtitle">Parcours d’excellence</p>
+        <h1>Réservez votre stage Tennis Impact</h1>
+        <p>Renseignez vos préférences de dates, le profil du joueur et nous reviendrons vers vous avec une proposition personnalisée incluant hébergement et services premium.</p>
+        <div class="hero__actions">
+          <a class="btn btn--gold" href="#devis">Construire mon devis</a>
+          <a class="hero__link hero__link--light" href="mailto:contact@tennisimpact.fr">
+            Parler à un conseiller
+            <span class="hero__link-icon" aria-hidden="true">↗</span>
+          </a>
+        </div>
+      </div>
+    </section>
 
-// Simulation d'envoi avec fermeture automatique
-document.addEventListener("DOMContentLoaded", function () {
-  const form = document.querySelector("#form-popup form");
-  if (form) {
-    form.addEventListener("submit", function (e) {
-      e.preventDefault();
-      console.log("Formulaire soumis. Simulation EmailJS.");
-      // Remplace ce bloc par EmailJS.send(...) plus tard
-      setTimeout(() => {
-        alert("Formulaire envoyé !");
-        closeForm();
-      }, 1000);
+    <section class="section" id="formules">
+      <div class="container">
+        <span class="eyebrow">Formules disponibles</span>
+        <h2>Des expériences pour tous les objectifs</h2>
+        <div class="stage-options">
+          <article class="option-card">
+            <h3>Performance Intensive</h3>
+            <p><strong>1 semaine • 1 600 €</strong> (hors hébergement)</p>
+            <ul>
+              <li>2 sessions tennis quotidiennes + préparation physique.</li>
+              <li>Analyse vidéo, coaching mental et suivi nutrition.</li>
+              <li>Option tournoi FFT ou UTR en fin de stage.</li>
+            </ul>
+          </article>
+          <article class="option-card">
+            <h3>Immersion Multisport</h3>
+            <p><strong>5 jours • 1 050 €</strong> (hors hébergement)</p>
+            <ul>
+              <li>1 entraînement tennis / jour + ateliers tactiques.</li>
+              <li>Activités complémentaires : golf, préparation mentale, yoga.</li>
+              <li>Sorties culturelles et team building premium.</li>
+            </ul>
+          </article>
+          <article class="option-card">
+            <h3>Tournée Compétition</h3>
+            <p><strong>10 jours • 4 200 €</strong> (hors hébergement)</p>
+            <ul>
+              <li>Coaching sur matchs officiels, routines de performance.</li>
+              <li>Bilans quotidiens, récupération cryo &amp; soins kiné.</li>
+              <li>Suivi digital 30 jours après le stage.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--dark" id="lieux">
+      <div class="container">
+        <div class="section__intro">
+          <span class="eyebrow eyebrow--light">Destinations 2024</span>
+          <h2>Choisissez votre écrin de performance</h2>
+          <p>Nos sites partenaires offrent un confort premium et des équipements haut de gamme.</p>
+        </div>
+        <div class="locations-grid">
+          <article class="location-tile">
+            <img src="https://images.unsplash.com/photo-1521412644187-c49fa049e84d?auto=format&fit=crop&w=1200&q=80" alt="Hostens" />
+            <div class="card__body">
+              <h3>Hostens – Landes</h3>
+              <p>Nature préservée, lac privé, infrastructures haut de gamme pour un stage oxygénant.</p>
+              <p><strong>+ Hébergement premium disponible.</strong></p>
+            </div>
+          </article>
+          <article class="location-tile">
+            <img src="https://images.unsplash.com/photo-1544322435-5b07c1309b20?auto=format&fit=crop&w=1200&q=80" alt="Poitiers" />
+            <div class="card__body">
+              <h3>CREPS Poitiers</h3>
+              <p>Centre d’excellence avec salles de préparation physique, staff médical et restauration dédiée.</p>
+              <p><strong>+ Option Futuroscope incluse.</strong></p>
+            </div>
+          </article>
+          <article class="location-tile">
+            <img src="https://images.unsplash.com/photo-1560582861-45078880e48e?auto=format&fit=crop&w=1200&q=80" alt="Aix-en-Provence" />
+            <div class="card__body">
+              <h3>Aix-en-Provence</h3>
+              <p>Climat idéal, surfaces variées et programme tennis &amp; français pour une immersion complète.</p>
+              <p><strong>+ Hébergement en résidence 4★.</strong></p>
+            </div>
+          </article>
+          <article class="location-tile">
+            <img src="https://images.unsplash.com/photo-1518081461904-9d8f136351c8?auto=format&fit=crop&w=1200&q=80" alt="Cabourg" />
+            <div class="card__body">
+              <h3>Cabourg</h3>
+              <p>Atmosphère littoral chic, night sessions, sorties bien-être et golf à proximité.</p>
+              <p><strong>+ Option famille disponible.</strong></p>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="devis">
+      <div class="container booking-form">
+        <span class="eyebrow">Créons votre devis premium</span>
+        <h2>Partagez vos attentes, nous nous occupons du reste</h2>
+        <form id="bookingForm">
+          <input type="text" name="name" placeholder="Nom &amp; Prénom du joueur" required />
+          <input type="email" name="email" placeholder="Email du parent" required />
+          <input type="tel" name="phone" placeholder="Téléphone" required />
+          <select name="stage" required>
+            <option value="" disabled selected>Stage souhaité</option>
+            <option value="performance">Performance Intensive</option>
+            <option value="multisport">Immersion Multisport</option>
+            <option value="tournoi">Tournée Compétition</option>
+          </select>
+          <select name="destination" required>
+            <option value="" disabled selected>Destination préférée</option>
+            <option value="hostens">Hostens – Landes</option>
+            <option value="poitiers">CREPS Poitiers</option>
+            <option value="aix">Aix-en-Provence</option>
+            <option value="cabourg">Cabourg</option>
+          </select>
+          <input type="date" name="date" placeholder="Semaine souhaitée" required />
+          <textarea name="details" placeholder="Précisez le niveau de jeu, objectifs et besoins en hébergement"></textarea>
+          <button class="btn btn--gold" type="submit">Envoyer ma demande</button>
+        </form>
+      </div>
+    </section>
+
+    <section class="container contact-banner">
+      <p>Besoin d’un accompagnement immédiat ? <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a> • +33 6 00 00 00 00</p>
+    </section>
+  </main>
+
+  <script>
+    const navToggle = document.getElementById('navToggle');
+    const mainNav = document.getElementById('mainNav');
+    const bookingForm = document.getElementById('bookingForm');
+
+    navToggle?.addEventListener('click', () => {
+      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+      navToggle.setAttribute('aria-expanded', String(!expanded));
+      mainNav.classList.toggle('is-open');
+      document.body.classList.toggle('no-scroll', !expanded);
     });
-  }
-});
-</script>
-<section class="methodologie" id="methodologie" style="background:#ffffff; color:#111; padding: 80px 20px; margin-top: 80px;">
-<div data-aos="fade-up" style="max-width: 1200px; margin: auto; display: flex; flex-wrap: wrap; align-items: center; gap: 40px;">
-<div style="flex: 1 1 500px;">
-<span id="methodologie"></span><h2 style="font-size: 2em; margin-bottom: 20px; color: #000;">Notre Méthodologie</h2>
-<p style="margin-bottom: 20px;">
-        À Tennis Impact, nous croyons qu’il n’existe pas de méthode unique. Chaque joueur est unique et mérite une approche personnalisée, en accord avec sa personnalité, ses besoins et ses objectifs. 
-        C’est pourquoi notre méthodologie repose sur cinq piliers fondamentaux :
-      </p>
-<ul style="list-style-type: none; padding: 0;">
-<li><strong>Écoute :</strong> Comprendre profondément chaque athlète, au-delà des mots.</li>
-<li><strong>Coaching individualisé :</strong> Construire des programmes d’entraînement adaptés aux besoins spécifiques de chacun.</li>
-<li><strong>Poursuite de l’excellence :</strong> Viser toujours plus haut, repousser les limites, et ne jamais se satisfaire de l’acquis.</li>
-<li><strong>Culture du résultat :</strong> Se concentrer sur des performances tangibles, sur et en dehors du court.</li>
-<li><strong>Remise en question permanente :</strong> Innover sans cesse pour progresser chaque jour.</li>
-</ul>
-</div>
-<div style="flex: 1 1 400px; text-align: center;">
-<img alt="Méthodologie Tennis" src="assets/photos/6.png" style="max-width: 100%; border-radius: 12px;"/>
-</div>
-</div>
-</section>
-<div style="width:100%; overflow:hidden; line-height:0; margin-top: -1px;">
-<svg preserveaspectratio="none" style="height:60px; width:100%;" viewbox="0 0 500 60">
-<path d="M0,0 C150,60 350,0 500,60 L500,00 L0,0 Z" style="stroke: none; fill: #f7f7f7;"></path>
-</svg>
-</div>
-<section id="nos-hebergements" style="background-color:#f7f7f7; padding: 80px 20px; color: #111;">
-<div style="max-width: 1200px; margin: auto;">
-<h2 style="text-align: center; font-size: 2.2em; margin-bottom: 40px;">Nos Hébergements</h2>
-<p style="text-align: center; max-width: 800px; margin: 0 auto 60px;">
-      Afin de proposer à nos stagiaires un cadre optimal alliant confort, sécurité et proximité avec les installations sportives,
-      Tennis Impact s'appuie sur des partenariats avec des structures reconnues partout en France.
-      Chaque lieu d’hébergement a été sélectionné pour offrir les meilleures conditions de récupération et de convivialité.
-    </p>
-<div style="display: flex; flex-wrap: wrap; justify-content: center; gap: 30px; text-align: center;">
-<!-- Cartouche Hostens -->
-<div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-<img alt="Hostens" src="assets/photos/1.png" style="width: 100%; height: 180px; object-fit: cover;"/>
-<div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-<h3 style="margin: 0 0 10px;">Hostens</h3>
-<p style="font-size: 0.95em;">Un site naturel en pleine forêt pour une immersion sportive et reposante près de Bordeaux.</p>
-<div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-poitiers')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-</div>
-</div>
-<!-- Cartouche Poitiers -->
-<div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-<img alt="CREPS Poitiers" src="assets/photos/2.png" style="width: 100%; height: 180px; object-fit: cover;"/>
-<div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-<h3 style="margin: 0 0 10px;">CREPS Poitiers</h3>
-<p style="font-size: 0.95em;">Une infrastructure moderne adaptée à l’entraînement de haut niveau et au repos des athlètes.</p>
-<div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-toulouse')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-</div>
-</div>
-<!-- Cartouche Aix-en-Provence -->
-<div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-<img alt="CREPS Aix-en-Provence" src="assets/photos/3.png" style="width: 100%; height: 180px; object-fit: cover;"/>
-<div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-<h3 style="margin: 0 0 10px;">CREPS Aix-en-Provence</h3>
-<p style="font-size: 0.95em;">Cadre ensoleillé avec accès direct aux courts et équipements sportifs de haut standing.</p>
-<div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-aix')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-</div>
-</div>
-<!-- Cartouche Toulouse -->
-<div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-<img alt="CREPS Toulouse" src="assets/photos/4.png" style="width: 100%; height: 180px; object-fit: cover;"/>
-<div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-<h3 style="margin: 0 0 10px;">CREPS Toulouse</h3>
-<p style="font-size: 0.95em;">Confort et accessibilité dans un cadre urbain dynamique avec toutes les commodités à proximité.</p>
-<div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-cabourg')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-</div>
-</div>
-<!-- Cartouche La Baule -->
-<div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-<img alt="La Baule" src="assets/photos/5.png" style="width: 100%; height: 180px; object-fit: cover;"/>
-<div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-<h3 style="margin: 0 0 10px;">La Baule</h3>
-<p style="font-size: 0.95em;">Station balnéaire prisée, parfaite pour allier stage de tennis et ambiance bord de mer.</p>
-<div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-hostens')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-</div>
-</div>
-<!-- Cartouche Cabourg -->
-<div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-<img alt="Cabourg" src="assets/photos/6.png" style="width: 100%; height: 180px; object-fit: cover;"/>
-<div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-<h3 style="margin: 0 0 10px;">Cabourg</h3>
-<p style="font-size: 0.95em;">Un cadre paisible et élégant sur la côte normande, pour une récupération optimale.</p>
-<div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-hostens')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-</div>
-</div>
-</div>
-</div>
-</section>
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-<!-- POPUPS -->
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-<div class="popup-hebergement" id="popup-hostens">
-<div class="popup-content">
-<span class="popup-close" onclick="fermerPopup()">×</span>
-<img alt="Stage à Hostens" src="assets/photos/1.png" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;"/>
-<h2>Stage à Hostens</h2>
-<p>Situé au cœur de la forêt des Landes, le site d’Hostens offre un cadre exceptionnel entre lacs et nature. Les stagiaires évoluent sur des terrains en plein air avec un encadrement de qualité.</p>
-<h3 style="margin-top:20px;">Journée type :</h3>
-<ul style="text-align:left; max-width: 600px; margin: 10px auto;">
-<li>8h00 – Petit déjeuner</li>
-<li>9h00 – Entraînement tennis (technique)</li>
-<li>11h00 – Préparation physique</li>
-<li>12h30 – Déjeuner</li>
-<li>14h00 – Matchs dirigés</li>
-<li>16h00 – Activité détente / lac</li>
-<li>19h00 – Dîner &amp; briefing</li>
-</ul>
-<button class="btn-ajouter-panier" onclick="ajouterAuPanier('Stage Hostens')">Ajouter au panier</button>
-</div>
-</div>
 
-<div class="popup-hebergement" id="popup-poitiers">
-<div class="popup-content">
-<span class="popup-close" onclick="fermerPopup()">×</span>
-<img alt="CREPS Poitiers - Vue aérienne" src="assets/photos/creps_poitiers_1.jpg" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;"/>
-<h2>Stage au CREPS de Poitiers</h2>
-<p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-</div>
-</div>
-<div class="popup-hebergement" id="popup-aix">
-<div class="popup-content">
-<span class="popup-close" onclick="fermerPopup()">×</span>
-<img alt="Stage au CREPS d’Aix-en-Provence" src="assets/photos/3.png" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;"/>
-<h2>Stage au CREPS d’Aix-en-Provence</h2>
-<p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-</div>
-</div>
-<div class="popup-hebergement" id="popup-toulouse">
-<div class="popup-content">
-<span class="popup-close" onclick="fermerPopup()">×</span>
-<img alt="Stage au CREPS de Toulouse" src="assets/photos/4.png" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;"/>
-<h2>Stage au CREPS de Toulouse</h2>
-<p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-</div>
-</div>
-<div class="popup-hebergement" id="popup-baule">
-<div class="popup-content">
-<span class="popup-close" onclick="fermerPopup()">×</span>
-<img alt="Stage à La Baule" src="assets/photos/5.png" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;"/>
-<h2>Stage à La Baule</h2>
-<p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-</div>
-</div>
-<div class="popup-hebergement" id="popup-cabourg">
-<div class="popup-content">
-<span class="popup-close" onclick="fermerPopup()">×</span>
-<img alt="Stage à Cabourg" src="assets/photos/6.png" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;"/>
-<h2>Stage à Cabourg</h2>
-<p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-</div>
-</div>
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-<script>
-function ouvrirPopup(id) {
-  document.querySelectorAll('.popup-hebergement').forEach(p => p.style.display = 'none');
-  const el = document.getElementById(id);
-  if (el) el.style.display = 'flex';
-}
-function fermerPopup() {
-  document.querySelectorAll('.popup-hebergement').forEach(p => p.style.display = 'none');
-}
-</script>
+    mainNav?.querySelectorAll('a, button').forEach(link => {
+      link.addEventListener('click', () => {
+        if (mainNav.classList.contains('is-open')) {
+          mainNav.classList.remove('is-open');
+          document.body.classList.remove('no-scroll');
+          navToggle?.setAttribute('aria-expanded', 'false');
+        }
+      });
+    });
 
-
-<div id="popup-poitiers" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage Futuroscope - Poitiers</h2>
-    <div class="popup-images"><img src="assets/photos/creps_poitiers_1.jpg" alt="Poitiers" /></div>
-    <div class="popup-text">
-      <p>Le CREPS de Poitiers combine entraînement et découverte culturelle avec une sortie exceptionnelle au Futuroscope.</p>
-      <h3>Journée type :</h3><ul>
-        <li>2 séances tennis</li>
-        <li>Préparation mentale</li>
-        <li>Sortie au Futuroscope</li>
-      </ul>
-    </div>
-  </div>
-</div>
-<div id="popup-toulouse" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage + Cité de l’Espace - Toulouse</h2>
-    <div class="popup-images"><img src="assets/photos/creps toulouse.jpg" alt="Toulouse" /></div>
-    <div class="popup-text">
-      <p>Entraînement complet + sortie exceptionnelle à la Cité de l’Espace.</p>
-      <h3>Journée type :</h3><ul>
-        <li>2 séances tennis / jour</li>
-        <li>Prépa physique & vidéo</li>
-        <li>Sortie découverte scientifique</li>
-      </ul>
-    </div>
-  </div>
-</div>
-<div id="popup-aix" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage intensif - Aix-en-Provence</h2>
-    <div class="popup-images"><img src="assets/photos/creps aix en provence.jpg" alt="Aix" /></div>
-    <div class="popup-text">
-      <p>Un cadre provençal pour progresser avec des infrastructures de haut niveau.</p>
-      <h3>Journée type :</h3><ul>
-        <li>2 séances tennis</li>
-        <li>Renforcement musculaire</li>
-        <li>Analyse vidéo</li>
-      </ul>
-    </div>
-  </div>
-</div>
-<div id="popup-cabourg" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Tournée de tournois - Cabourg</h2>
-    <div class="popup-images"><img src="assets/photos/cabourg-tennis-club-sporting.webp" alt="Cabourg" /></div>
-    <div class="popup-text">
-      <p>Stage compétition avec participation à des tournois FFT tout au long de la semaine.</p>
-      <h3>Journée type :</h3><ul>
-        <li>Matchs FFT chaque jour</li>
-        <li>Coaching individualisé</li>
-        <li>Analyse tactique</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<script>
-function openPopup(id) {
-  document.getElementById(id).style.display = 'block';
-}
-function closePopup(e) {
-  if (e.target.classList.contains('popup') || e.target.classList.contains('close')) {
-    e.target.closest('.popup').style.display = 'none';
-  }
-}
-</script>
-
-
-
-
-<div id="popup-poitiers" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage avec sortie Futuroscope - Poitiers</h2>
-    <div class="popup-images"><img src="assets/photos/creps_poitiers_1.jpg" alt="Poitiers" /></div>
-    <div class="popup-text">
-      <p>Entraînement intensif dans une structure moderne avec en bonus une sortie exceptionnelle au parc du Futuroscope.</p>
-      <h3>Journée type :</h3>
-      <ul>
-        <li>2 séances tennis</li>
-        <li>Préparation mentale</li>
-        <li>Sortie d'une journée au Futuroscope</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-toulouse" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage + Cité de l’Espace - Toulouse</h2>
-    <div class="popup-images"><img src="assets/photos/creps toulouse.jpg" alt="Toulouse" /></div>
-    <div class="popup-text">
-      <p>Un stage enrichi par une sortie à la Cité de l’Espace pour mêler sport et culture scientifique dans un cadre motivant.</p>
-      <h3>Journée type :</h3>
-      <ul>
-        <li>2 entraînements tennis par jour</li>
-        <li>Renforcement musculaire + analyse vidéo</li>
-        <li>Sortie scientifique à la Cité de l’Espace</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-aix" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage intensif - Aix-en-Provence</h2>
-    <div class="popup-images"><img src="assets/photos/creps aix en provence.jpg" alt="Aix" /></div>
-    <div class="popup-text">
-      <p>Cadre ensoleillé au cœur de la Provence pour un stage haut niveau alliant tennis, prépa physique et récupération.</p>
-      <h3>Journée type :</h3>
-      <ul>
-        <li>2 séances tennis intensives</li>
-        <li>Préparation physique encadrée</li>
-        <li>Analyse vidéo + détente</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-cabourg" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Tournée de Tournois - Cabourg</h2>
-    <div class="popup-images"><img src="assets/photos/cabourg-tennis-club-sporting.webp" alt="Cabourg" /></div>
-    <div class="popup-text">
-      <p>Stage de compétition en bord de mer avec participation à des tournois FFT officiels et coaching personnalisé quotidien.</p>
-      <h3>Journée type :</h3>
-      <ul>
-        <li>1 match FFT par jour</li>
-        <li>Coaching tactique après chaque rencontre</li>
-        <li>Analyse vidéo + récupération</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-
-<!-- POPUPS PREMIUM FINAUX -->
-<div id="popup-hostens" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage Multisport - Hostens</h2>
-    <div class="popup-images"><img src="assets/photos/hostens_kurs.jpg" alt="Hostens" /></div>
-    <div class="popup-text">
-      <p>Un stage multisport dans un cadre naturel exceptionnel mêlant tennis, paddle, VTT et baignade en lac.</p>
-      <h3>Journée type :</h3><ul>
-        <li>1 séance tennis + activité extérieure</li>
-        <li>Déjeuner au bord du lac</li>
-        <li>Soirée animée (grillades, jeux)</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-poitiers" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage avec sortie Futuroscope - Poitiers</h2>
-    <div class="popup-images"><img src="assets/photos/1200x680_creps_2_poitiers.jpg" alt="Poitiers" /></div>
-    <div class="popup-text">
-      <p>Entraînement intensif dans une structure moderne avec en bonus une sortie exceptionnelle au parc du Futuroscope.</p>
-      <h3>Journée type :</h3><ul>
-        <li>2 séances tennis</li>
-        <li>Préparation mentale</li>
-        <li>Sortie d'une journée au Futuroscope</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-toulouse" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage + Cité de l’Espace - Toulouse</h2>
-    <div class="popup-images"><img src="assets/photos/creps toulouse.jpg" alt="Toulouse" /></div>
-    <div class="popup-text">
-      <p>Un stage enrichi par une sortie à la Cité de l’Espace pour mêler sport et culture scientifique dans un cadre motivant.</p>
-      <h3>Journée type :</h3><ul>
-        <li>2 entraînements tennis par jour</li>
-        <li>Renforcement musculaire + analyse vidéo</li>
-        <li>Sortie scientifique à la Cité de l’Espace</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-aix" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage intensif - Aix-en-Provence</h2>
-    <div class="popup-images"><img src="assets/photos/creps aix en provence.jpg" alt="Aix" /></div>
-    <div class="popup-text">
-      <p>Cadre ensoleillé au cœur de la Provence pour un stage haut niveau alliant tennis, prépa physique et récupération.</p>
-      <h3>Journée type :</h3><ul>
-        <li>2 séances tennis intensives</li>
-        <li>Préparation physique encadrée</li>
-        <li>Analyse vidéo + détente</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-cabourg" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Tournée de Tournois - Cabourg</h2>
-    <div class="popup-images"><img src="assets/photos/cabourg-tennis-club-sporting.webp" alt="Cabourg" /></div>
-    <div class="popup-text">
-      <p>Stage compétition en bord de mer avec participation à des tournois FFT officiels et coaching personnalisé quotidien.</p>
-      <h3>Journée type :</h3><ul>
-        <li>1 match FFT par jour</li>
-        <li>Coaching tactique après chaque rencontre</li>
-        <li>Analyse vidéo + récupération</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-
-<script>
-(function(){
-  function adjust() {
-    var hash = window.location.hash;
-    if(!hash) return;
-    var el = document.querySelector(hash);
-    if(!el) return;
-    var header = document.querySelector('header, .site-header, nav.navbar, .navbar');
-    var offset = 0;
-    if (header) { offset = header.getBoundingClientRect().height || 0; }
-    var y = el.getBoundingClientRect().top + window.pageYOffset - (offset + 16);
-    window.scrollTo({top: y, behavior: 'instant'});
-  }
-  window.addEventListener('load', adjust);
-  window.addEventListener('hashchange', function(){ setTimeout(adjust, 0); });
-  // handle direct clicks with default prevented by some scripts
-  document.addEventListener('click', function(e){
-    var a = e.target.closest('a[href*="#nos-hebergements"]');
-    if(a){
-      e.preventDefault();
-      history.pushState(null, '', a.getAttribute('href').split('#')[0] + '#nos-hebergements');
-      adjust();
-    }
-  }, true);
-})();
-</script>
-
-
-<script>
-(function(){
-  function headerOffset(){
-    var sel = ['header','.site-header','.navbar','nav','.topbar'];
-    for (var i=0;i<sel.length;i++){
-      var el = document.querySelector(sel[i]);
-      if(el){ var h = el.getBoundingClientRect().height; if(h>0) return Math.round(h)+16; }
-    }
-    return 140;
-  }
-  function scrollToAnchorNosHebergements(){
-    var el = document.querySelector('#nos-hebergements') || document.getElementById('nos-hebergements');
-    if(!el) return;
-    var off = headerOffset();
-    document.documentElement.style.setProperty('--header-offset', off+'px');
-    var target = el;
-    // If next heading is immediately after anchor, prefer heading
-    var next = el.nextElementSibling;
-    if(next && /^H[1-6]$/.test(next.tagName)) target = next;
-    var y = target.getBoundingClientRect().top + window.pageYOffset - off;
-    window.scrollTo({top:y, behavior:'instant'});
-  }
-  function wantNosHash(){
-    return (location.hash || '').toLowerCase().indexOf('nos-hebergements') !== -1;
-  }
-  window.addEventListener('load', function(){
-    if(wantNosHash()) { setTimeout(scrollToAnchorNosHebergements, 0); }
-  });
-  window.addEventListener('hashchange', function(){
-    if(wantNosHash()) { setTimeout(scrollToAnchorNosHebergements, 0); }
-  });
-  document.addEventListener('click', function(e){
-    var a = e.target.closest('a[href*="#nos-hebergements"]');
-    if(a){
-      e.preventDefault();
-      if(a.getAttribute('href').indexOf('#')===0){
-        history.pushState(null,'','#nos-hebergements');
-      }else{
-        var base = a.getAttribute('href').split('#')[0];
-        history.pushState(null,'', base+'#nos-hebergements');
-      }
-      scrollToAnchorNosHebergements();
-    }
-  }, true);
-})();
-</script>
-
+    bookingForm?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      alert('Merci ! Un conseiller Tennis Impact vous recontactera sous 24h.');
+      bookingForm.reset();
+    });
+  </script>
 </body>
 </html>
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-<!-- POPUPS INDIVIDUELS PAR LIEU -->
-<!-- POPUP HOSTENS -->
-<div class="popup-overlay" id="popup-hostens" style="display:none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.75); z-index: 1000; justify-content: center; align-items: center;">
-<div class="popup-content" style="background: white; max-width: 900px; width: 90%; border-radius: 15px; overflow: hidden; position: relative; animation: fadeIn 0.4s ease;">
-<span onclick="closePopup('popup-hostens')" style="position: absolute; top: 15px; right: 20px; font-size: 24px; cursor: pointer;">×</span>
-<div style="display: flex; flex-direction: column;">
-<img alt="Hostens" src="assets/photos/1.png" style="width: 100%; height: 300px; object-fit: cover;"/>
-<div style="padding: 30px;">
-<h2 style="margin-top: 0;">Stage à Hostens</h2>
-<p><strong>Un site naturel en pleine forêt pour une immersion sportive et reposante près de Bordeaux.</strong></p>
-<p><em>Plus que 8 places disponibles</em></p>
-<p style="font-size: 1.2em; font-weight: bold;">1600 € <span style="font-size: 0.8em; font-weight: normal;">*Prix sans hébergement</span></p>
-<h3>Description</h3>
-<p>Le site d’Hostens, situé dans une réserve naturelle, offre un cadre exceptionnel pour une pratique intensive du tennis. Les infrastructures sportives sont à proximité immédiate du centre d’hébergement, garantissant confort, sécurité et efficacité dans les déplacements.</p>
-<h3>Une journée type :</h3>
-<ul>
-<li>7h30 : Réveil &amp; petit-déjeuner</li>
-<li>9h00 - 12h00 : Entraînement tennis + préparation physique</li>
-<li>12h30 : Déjeuner &amp; temps calme</li>
-<li>14h30 - 17h00 : Tennis, matchs, coaching mental</li>
-<li>18h00 : Activité détente (lac, forêt, vélo)</li>
-<li>20h00 : Dîner &amp; briefing du lendemain</li>
-</ul>
-<h3>Prestations incluses :</h3>
-<ul>
-<li>Encadrement par coachs diplômés</li>
-<li>Analyse vidéo &amp; coaching personnalisé</li>
-<li>Accès aux infrastructures sportives</li>
-<li>Maillot Tennis Impact offert</li>
-</ul>
-<button style="margin-top: 20px; padding: 12px 24px; background: #000; color: #fff; border: none; border-radius: 25px; font-size: 1em; cursor: pointer;">Ajouter ce stage</button>
-</div>
-</div>
-</div>
-</div>
-<script>
-function openPopup(id) {
-  document.getElementById(id).style.display = "flex";
-}
-function closePopup(id) {
-  document.getElementById(id).style.display = "none";
-}
-window.addEventListener('click', function(e) {
-  const popup = document.getElementById('popup-hostens');
-  if (e.target === popup) closePopup('popup-hostens');
-});
-</script>
-<!-- POPUP FORMULAIRE -->
-<div class="popup-overlay" id="popup-formulaire" style="display:none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.75); z-index: 10000; justify-content: center; align-items: center;">
-<div class="popup-content" style="background: white; max-width: 600px; width: 90%; border-radius: 15px; overflow: hidden; position: relative; animation: fadeIn 0.4s ease; padding: 30px; font-family: Poppins, sans-serif;">
-<span onclick="closePopup('popup-formulaire')" style="position: absolute; top: 15px; right: 20px; font-size: 24px; cursor: pointer;">×</span>
-<h2 style="margin-top: 0; text-align:center;">Réserver mon stage</h2>
-<form id="form-reservation">
-<label>Prénom</label><br/>
-<input name="prenom" required="" style="width:100%; padding:10px; margin-bottom:10px;" type="text"/><br/>
-<label>Nom</label><br/>
-<input name="nom" required="" style="width:100%; padding:10px; margin-bottom:10px;" type="text"/><br/>
-<label>Âge</label><br/>
-<input name="age" required="" style="width:100%; padding:10px; margin-bottom:10px;" type="number"/><br/>
-<label>Email</label><br/>
-<input name="email" required="" style="width:100%; padding:10px; margin-bottom:10px;" type="email"/><br/>
-<label>Téléphone</label><br/>
-<input name="tel" required="" style="width:100%; padding:10px; margin-bottom:10px;" type="tel"/><br/>
-<label>Niveau</label><br/>
-<select name="niveau" required="" style="width:100%; padding:10px; margin-bottom:10px;">
-<option value="">Sélectionner</option>
-<option>Débutant</option>
-<option>Intermédiaire</option>
-<option>Avancé</option>
-<option>Classé FFT</option>
-</select><br/>
-<label>Nos Hébergements</label><br/>
-<select name="hebergement" required="" style="width:100%; padding:10px; margin-bottom:20px;">
-<option value="">Sélectionner</option>
-<option>Avec hébergement</option>
-<option>Sans hébergement</option>
-</select><br/>
-<button style="width:100%; padding:12px; background:#000; color:#fff; border:none; border-radius:25px; font-size:1em;" type="submit">Envoyer ma réservation</button>
-</form>
-</div>
-</div>
-<script>
-function validerReservation() {
-  document.getElementById('popup-formulaire').style.display = "flex";
-}
-</script>

--- a/reserver_popup_hostens.html
+++ b/reserver_popup_hostens.html
@@ -1,953 +1,182 @@
-
 <!DOCTYPE html>
-
 <html lang="fr">
 <head>
-<meta charset="utf-8"/>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Réserver un Stage - Tennis Impact</title>
-<link href="style.css" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Playfair+Display&amp;family=Poppins:wght@300;400;600&amp;display=swap" rel="stylesheet"/>
-<style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Hostens – Détail du stage Tennis Impact</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
     body {
-      font-family: 'Poppins', sans-serif;
-      background-color: #0d0d1f;
-      color: #fff;
-      margin: 0;
-      padding: 0;
+      background: #f6f7fb;
+      color: var(--color-navy);
     }
-    .container {
-  display: grid;
-  grid-template-columns: 2fr 1fr;
-  align-items: start;
-  gap: 40px;
-  min-height: 100vh;
 
-    .stage-card {
-      background: white;
-      color: black;
-      border-radius: 20px;
-      overflow: hidden;
-      box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-      margin-bottom: 30px;
-      max-width: 500px;
+    .hostens-hero {
+      position: relative;
+      padding: 110px 0 80px;
+      background: linear-gradient(120deg, rgba(5, 10, 15, 0.82), rgba(13, 27, 42, 0.82)),
+        url('https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?auto=format&fit=crop&w=1800&q=80') center/cover;
+      color: var(--color-white);
     }
-    .stage-card img {
-      width: 100%;
-      height: auto;
-    }
-    .stage-card .content {
-      padding: 20px;
-    }
-    .stage-card h3 {
-      font-family: 'Playfair Display', serif;
-      margin-top: 0;
-      color: #0d0d1f;
-    }
-    .stage-card .price {
-      font-weight: bold;
-      color: #b28d00;
-    }
-    .stage-card ul {
-      padding-left: 20px;
-    }
-    .stage-card button {
-      background-color: #0d0d1f;
-      color: white;
-      border: none;
-      padding: 12px 20px;
-      border-radius: 10px;
-      cursor: pointer;
-      margin-top: 15px;
-    }
-    .cart {
-  position: -webkit-sticky;
-  position: sticky;
-  top: 40px;
-  align-self: start;
-  background: #1a1a2e;
-  border-radius: 20px;
-  padding: 30px;
-  box-shadow: 0 4px 20px rgba(255, 215, 0, 0.2);
-  min-width: 300px;
-  color: white;
-}
-    .cart h2 {
-      color: #fdd835;
-      font-family: 'Playfair Display', serif;
-    }
-    .cart-item {
-      background: #111;
-      margin-bottom: 15px;
-      padding: 15px;
-      border-radius: 10px;
-    }
-    .cart-item span {
-      display: block;
-    }
-    .cart button {
-      width: 100%;
-      background-color: #fdd835;
-      color: #0d0d1f;
-      font-weight: bold;
-      padding: 15px;
-      border: none;
-      border-radius: 12px;
-      cursor: pointer;
-      margin-top: 20px;
-    }
-  
-.premium-form {
-  background: #ffffff;
-  border: 2px solid #fdd835;
-  box-shadow: 0 0 40px rgba(255, 215, 0, 0.25);
-  border-radius: 20px;
-  padding: 40px;
-  font-family: 'Poppins', sans-serif;
-  color: #0d0d1f;
-}
-.premium-form h2 {
-  font-family: 'Playfair Display', serif;
-  font-size: 28px;
-  color: #0d0d1f;
-}
-.premium-form input,
-.premium-form select {
-  width: 100%;
-  margin-bottom: 15px;
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px solid #ccc;
-}
-.premium-form button[type='submit'] {
-  background-color: #0d0d1f;
-  color: #fdd835;
-  font-weight: bold;
-  padding: 12px 20px;
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-}
-.premium-form button[type='button'] {
-  background-color: #bbb;
-  color: white;
-  margin-left: 10px;
-  padding: 12px 20px;
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-}
 
+    .hostens-hero h1 {
+      font-family: var(--font-heading);
+      font-size: clamp(2.4rem, 4vw, 3.2rem);
+      margin-bottom: 1rem;
+    }
 
-.stages {
-  padding-right: 20px;
-  border-right: 1px solid rgba(255, 255, 255, 0.1);
-}
-.cart {
-  padding-left: 30px;
-  background: #12122a;
-}
+    .hostens-hero p {
+      max-width: 680px;
+      font-size: 1.1rem;
+    }
 
+    .content-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 2rem;
+      margin-top: 3rem;
+    }
 
-@keyframes fadeZoomIn {
-  0% { opacity: 0; transform: scale(0.8) translate(-50%, -50%); }
-  100% { opacity: 1; transform: scale(1) translate(-50%, -50%); }
-}
-#form-popup {
-  animation: fadeZoomIn 0.4s ease-out;
-}
+    .info-card {
+      background: var(--color-white);
+      border-radius: var(--radius-card);
+      box-shadow: var(--shadow-soft);
+      padding: 1.8rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
 
+    .info-card img {
+      border-radius: var(--radius-card);
+    }
 
-.stage-card {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  background: white;
-  color: black;
-  border-radius: 20px;
-  overflow: hidden;
-  box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-  margin-bottom: 30px;
-  max-width: 100%;
-}
-.stage-card img {
-  width: 300px;
-  height: auto;
-  object-fit: cover;
-}
-.stage-card .content {
-  padding: 20px;
-  flex: 1;
-}
+    .program-list {
+      list-style: disc;
+      padding-left: 1.2rem;
+      color: var(--color-grey-600);
+      line-height: 1.5;
+    }
 
-</style>
-<script>
-function openForm(stageName) {
-  const popup = document.getElementById("form-popup");
-  const input = popup.querySelector("input[name='stage'], select[name='stage']");
-  if (input) input.value = stageName;
-  popup.style.display = "block";
-}
+    .cta-box {
+      margin-top: 3rem;
+      background: linear-gradient(120deg, rgba(249, 214, 92, 0.95), rgba(217, 166, 0, 0.95));
+      border-radius: var(--radius-large);
+      padding: clamp(2.5rem, 4vw, 3.5rem);
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      color: var(--color-night);
+      box-shadow: var(--shadow-soft);
+    }
 
-function closeForm() {
-  document.getElementById("form-popup").style.display = "none";
-}
-
-// Simulation d'envoi avec fermeture automatique
-document.addEventListener("DOMContentLoaded", function () {
-  const form = document.querySelector("#form-popup form");
-  if (form) {
-    form.addEventListener("submit", function (e) {
-      e.preventDefault();
-      console.log("Formulaire soumis. Simulation EmailJS.");
-      // Remplace ce bloc par EmailJS.send(...) plus tard
-      setTimeout(() => {
-        alert("Formulaire envoyé !");
-        closeForm();
-      }, 1000);
-    });
-  }
-});
-</script>
+    .cta-box ul {
+      list-style: disc;
+      padding-left: 1.2rem;
+    }
+  </style>
 </head>
 <body>
-<section style="position: relative; width: 100%; height: 100vh; background: url('assets/photos/3.png') center/cover no-repeat; display: flex; align-items: center; justify-content: center;">
-<div style="background-color: rgba(0,0,0,0.55); padding: 40px; border-radius: 12px; color: white; text-align: center;">
-<h1 style="font-size: 2.5rem; margin: 0;">Réservez votre stage</h1>
-<h2 style="font-size: 1.6rem; font-weight: 300;">Choisissez vos dates et options d’hébergement</h2>
-<p style="margin-top: 10px; font-size: 1rem;">Académie Tennis Impact</p>
-</div>
-</section>
-<nav style="position: sticky; top: 0; z-index: 1000; background: white; border-bottom: 2px solid #eee; padding: 12px 20px; display: flex; justify-content: center; gap: 30px; font-weight: bold;">
-<a href="#stages" style="color: #001f3f; text-decoration: none;">Stages</a>
-<a href="#methode" style="color: #001f3f; text-decoration: none;">Méthodologie</a>
-<a href="reserver.html#nos-hebergements" style="color: #001f3f; text-decoration: none;">Nos Hébergements</a>
-<a href="#options" style="color: #001f3f; text-decoration: none;">Options</a>
-<a href="#faq" style="color: #001f3f; text-decoration: none;">FAQ</a>
-</nav>
+  <header class="navbar">
+    <div class="navbar__container">
+      <a class="navbar__brand" href="index.html" aria-label="Retour à l'accueil Tennis Impact">
+        <img src="assets/images/logo.svg" alt="Tennis Impact" />
+      </a>
+      <button class="navbar__toggle" id="navToggle" aria-expanded="false" aria-controls="mainNav" aria-label="Ouvrir le menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <nav class="navbar__links" id="mainNav" aria-label="Navigation principale">
+        <ul class="navbar__menu">
+          <li><a href="stages_jeunes.html" class="nav-link">Stages jeunes</a></li>
+          <li><a href="lecon_individuelle.html" class="nav-link">Leçons individuelles</a></li>
+          <li><a href="espace_coach.html" class="nav-link">Espace coach</a></li>
+          <li><a href="reserver.html" class="nav-link">Réserver un stage</a></li>
+          <li><a href="mailto:contact@tennisimpact.fr" class="nav-link nav-link--cta">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
 
+  <main>
+    <section class="hostens-hero">
+      <div class="container">
+        <p class="hero__subtitle">Destination nature</p>
+        <h1>Stage premium Hostens – Landes</h1>
+        <p>Une immersion au cœur d’un domaine forestier avec lac privé, installations haut de gamme et staff dédié. Idéal pour conjuguer intensité et récupération.</p>
+      </div>
+    </section>
 
+    <section class="section">
+      <div class="container content-grid">
+        <article class="info-card">
+          <img src="https://images.unsplash.com/photo-1521412644187-c49fa049e84d?auto=format&fit=crop&w=1200&q=80" alt="Site de Hostens" />
+          <div>
+            <h2>Infrastructures d’exception</h2>
+            <p>Courts extérieurs refaits à neuf, zone indoor, salle de préparation physique et espaces bien-être (sauna, cryo, balnéo).</p>
+          </div>
+        </article>
+        <article class="info-card">
+          <h2>Programme type</h2>
+          <ul class="program-list">
+            <li>08h30 – Activation &amp; préparation mentale.</li>
+            <li>10h00 – Bloc technique intensif (vidéo + coach référent).</li>
+            <li>14h00 – Matchs dirigés &amp; stratégies de compétition.</li>
+            <li>17h00 – Récupération active, cryothérapie, yoga.</li>
+            <li>20h00 – Debrief collectif &amp; ateliers nutrition.</li>
+          </ul>
+          <p>Encadrement 24/7, ratio 1 coach pour 4 joueurs.</p>
+        </article>
+        <article class="info-card">
+          <h2>Hébergement &amp; services</h2>
+          <p>Chambres premium 2 ou 3 lits, restauration sportive personnalisée et sécurité assurée par notre équipe résidente.</p>
+          <p>Transferts gare de Bordeaux inclus. Options familiales sur demande.</p>
+        </article>
+      </div>
+    </section>
 
-
-<section style="width: 100%; background-color: white; padding: 100px 20px 120px; position: relative;">
-<div style="max-width: 1000px; margin: auto; text-align: center;">
-<h2 style="color: #001f3f; font-size: 2.5rem; margin-bottom: 20px;">
-      Des stages tennis jeunes au cœur de la Côte d’Azur
-    </h2>
-<h3 style="color: #FFD700; font-size: 1.6rem; font-weight: bold; margin-bottom: 30px;">
-      OFFREZ À VOTRE ENFANT L’EXCELLENCE TENNIS IMPACT
-    </h3>
-<p style="font-size: 1.2rem; color: #333; line-height: 1.8;">
-      Chaque année, Tennis Impact accueille de nombreux jeunes joueurs venus de toute la France pour vivre une expérience unique alliant sport de haut niveau, développement personnel et plaisir du jeu.<br/><br/>
-      Nos stages de tennis pour jeunes sont conçus pour s’adapter à tous les profils : du joueur loisir au compétiteur ambitieux. Dans un environnement structuré, dynamique et bienveillant, votre enfant progresse à son rythme tout en découvrant les exigences du haut niveau.
-    </p>
-</div>
-<!-- Vague de séparation corrigée -->
-<div style="position: absolute; bottom: 0; left: 0; width: 100%; overflow: hidden; line-height: 0;">
-<svg preserveaspectratio="none" style="display: block; width: 100%; height: 70px;" viewbox="0 0 500 50">
-<path d="M0,30 C150,80 350,-10 500,30 L500,00 L0,0 Z" style="fill:#001f3f;"></path>
-</svg>
-</div>
-</section>
-
-
-
-<div class="container">
-<div class="stages">
-<div class="stage-card">
-<img alt="Stage INTENSIF" src="assets/photos/1.png"/>
-<div class="content">
-<h3>Stage INTENSIF</h3>
-<p>Journée entière • 23 juin - 28 juin</p>
-<p class="price">1 600,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>2 sessions de tennis en groupe par jour</li><li>3h d'activité physique</li><li>Rapport individuel</li><li>Repas du midi</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage COMPÉTITION" src="assets/photos/2.png"/>
-<div class="content">
-<h3>Stage COMPÉTITION</h3>
-<p>Journée entière • 23 juin - 05 juil.</p>
-<p class="price">4 200,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>2 sessions de tennis</li><li>Tournoi UTR inclus</li><li>Préparation mentale</li><li>Rapport individuel</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage DEMI-JOURNÉE" src="assets/photos/3.png"/>
-<div class="content">
-<h3>Stage DEMI-JOURNÉE</h3>
-<p>Demi journée • 23 juin - 28 juin</p>
-<p class="price">1 050,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>1 session de tennis</li><li>Rapport individuel</li><li>Matinée uniquement</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage INTENSIF + Français" src="assets/photos/4.png"/>
-<div class="content">
-<h3>Stage INTENSIF + Français</h3>
-<p>Journée entière • 30 juin - 05 juil.</p>
-<p class="price">1 750,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>Tennis + Français</li><li>1h30 de physique/jour</li><li>Repas du midi</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage TENNIS &amp; GOLF" src="assets/photos/5.png"/>
-<div class="content">
-<h3>Stage TENNIS &amp; GOLF</h3>
-<p>Journée entière • 30 juin - 05 juil.</p>
-<p class="price">1 700,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>Tennis le matin</li><li>Golf l’après-midi</li><li>Repas du midi</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage NIGHT SESSIONS" src="assets/photos/6.png"/>
-<div class="content">
-<h3>Stage NIGHT SESSIONS</h3>
-<p>Soir • 30 juin - 04 juil.</p>
-<p class="price">900,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>Sessions du soir</li><li>Cardio tennis</li><li>Welcome pack</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-</div>
-<div class="cart">
-<h2>Mon Panier</h2>
-<div class="cart-item">
-<span><strong>Stage INTENSIF</strong></span>
-<span>23 juin - 28 juin</span>
-<span>1 600,00 €</span>
-</div>
-<button onclick="openForm('Panier')">Valider l’inscription</button>
-</div>
-</div>
-<div id="form-popup" style="display: none; position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; padding: 40px; border-radius: 20px; z-index: 1000; max-width: 800px; width: 90%; max-height: 90vh; overflow-y: auto; font-family: Poppins, sans-serif;">
-<div style="display: flex; justify-content: space-between; align-items: center;">
-<h2 style="margin-top: 0; color: #0d0d1f;">Inscription au Stage</h2>
-<button onclick="closeForm()" style="background-color: #bbb; padding: 5px 10px; border: none; border-radius: 8px;">X</button>
-</div>
-<form>
-<div class="form-grid">
-<label for="lieu">
-     Lieu du stage
-    </label>
-<select id="lieu" name="lieu">
-<option value="Paris">
-      Paris
-     </option>
-<option value="Colmar">
-      Colmar
-     </option>
-</select>
-<label for="type_stage">
-     Type de stage
-    </label>
-<select id="type_stage" name="type_stage">
-<option value="Intensif">
-      Intensif
-     </option>
-<option value="Demi-journée">
-      Demi-journée
-     </option>
-<option value="Compétition">
-      Compétition
-     </option>
-</select>
-<div class="form-field">
-<label for="prenom">
-      Prénom
-     </label>
-</div>
-<div class="form-field">
-<input id="prenom" name="prenom" required="" type="text"/>
-</div>
-<div class="form-field">
-<label for="nom">
-      Nom
-     </label>
-</div>
-<div class="form-field">
-<input id="nom" name="nom" required="" type="text"/>
-</div>
-<div class="form-field">
-<label for="niveau">
-      Niveau FFT
-     </label>
-</div>
-<div class="form-field">
-<select id="niveau" name="niveau">
-<option value="">
-       -- Sélectionnez --
-      </option>
-<option>
-       Blanc
-      </option>
-<option>
-       Violet
-      </option>
-<option>
-       Rouge
-      </option>
-<option>
-       Orange
-      </option>
-<option>
-       Vert
-      </option>
-<option>
-       Jaune
-      </option>
-<option>
-       40
-      </option>
-<option>
-       30/5
-      </option>
-<option>
-       30/4
-      </option>
-<option>
-       30/3
-      </option>
-<option>
-       30/2
-      </option>
-<option>
-       30/1
-      </option>
-<option>
-       30
-      </option>
-<option>
-       15/5
-      </option>
-<option>
-       15/4
-      </option>
-<option>
-       15/3
-      </option>
-<option>
-       15/2
-      </option>
-<option>
-       15/1
-      </option>
-<option>
-       15
-      </option>
-<option>
-       -2/6
-      </option>
-<option>
-       -4/6
-      </option>
-<option>
-       -15
-      </option>
-</select>
-</div>
-<div class="form-field">
-<label for="date">
-      Semaine de Stage
-     </label>
-</div>
-<div class="form-field">
-<input id="date" name="date" required="" type="week"/>
-</div>
-<div class="form-field">
-<label for="hebergement">
-      Souhaitez-vous l’hébergement ?
-     </label>
-</div>
-<div class="form-field">
-<select id="hebergement" name="hebergement">
-<option value="">
-       -- Sélectionnez --
-      </option>
-<option>
-       Oui
-      </option>
-<option>
-       Non
-      </option>
-</select>
-</div>
-</div>
-<button type="submit">
-    Valider l'inscription
-   </button>
-</form>
-</div>
-<script>
-function openForm(stageName) {
-  const popup = document.getElementById("form-popup");
-  const input = popup.querySelector("input[name='stage'], select[name='stage']");
-  if (input) input.value = stageName;
-  popup.style.display = "block";
-}
-
-function closeForm() {
-  document.getElementById("form-popup").style.display = "none";
-}
-
-// Simulation d'envoi avec fermeture automatique
-document.addEventListener("DOMContentLoaded", function () {
-  const form = document.querySelector("#form-popup form");
-  if (form) {
-    form.addEventListener("submit", function (e) {
-      e.preventDefault();
-      console.log("Formulaire soumis. Simulation EmailJS.");
-      // Remplace ce bloc par EmailJS.send(...) plus tard
-      setTimeout(() => {
-        alert("Formulaire envoyé !");
-        closeForm();
-      }, 1000);
-    });
-  }
-});
-</script>
-
-<section id="methodologie" class="methodologie" style="background:#ffffff; color:#111; padding: 80px 20px; margin-top: 80px;">
-  <div style="max-width: 1200px; margin: auto; display: flex; flex-wrap: wrap; align-items: center; gap: 40px;" data-aos="fade-up">
-    <div style="flex: 1 1 500px;">
-      <h2 style="font-size: 2em; margin-bottom: 20px; color: #000;">Notre Méthodologie</h2>
-      <p style="margin-bottom: 20px;">
-        À Tennis Impact, nous croyons qu’il n’existe pas de méthode unique. Chaque joueur est unique et mérite une approche personnalisée, en accord avec sa personnalité, ses besoins et ses objectifs. 
-        C’est pourquoi notre méthodologie repose sur cinq piliers fondamentaux :
-      </p>
-      <ul style="list-style-type: none; padding: 0;">
-        <li><strong>Écoute :</strong> Comprendre profondément chaque athlète, au-delà des mots.</li>
-        <li><strong>Coaching individualisé :</strong> Construire des programmes d’entraînement adaptés aux besoins spécifiques de chacun.</li>
-        <li><strong>Poursuite de l’excellence :</strong> Viser toujours plus haut, repousser les limites, et ne jamais se satisfaire de l’acquis.</li>
-        <li><strong>Culture du résultat :</strong> Se concentrer sur des performances tangibles, sur et en dehors du court.</li>
-        <li><strong>Remise en question permanente :</strong> Innover sans cesse pour progresser chaque jour.</li>
+    <section class="container cta-box">
+      <h2>Prêt à confirmer votre stage à Hostens ?</h2>
+      <p>Notre équipe revient vers vous sous 24h avec le planning détaillé et les modalités de réservation.</p>
+      <ul>
+        <li>1 600 € la semaine (hors hébergement) – hébergement premium : +520 €.</li>
+        <li>Option activités outdoor : paddle, trail, ateliers nature.</li>
+        <li>Support concierge dédié pour les familles.</li>
       </ul>
-    </div>
-    <div style="flex: 1 1 400px; text-align: center;">
-      <img src="assets/photos/6.png" alt="Méthodologie Tennis" style="max-width: 100%; border-radius: 12px;">
-    </div>
-  </div>
-</section>
-
-<div style="width:100%; overflow:hidden; line-height:0; margin-top: -1px;">
-  <svg viewBox="0 0 500 60" preserveAspectRatio="none" style="height:60px; width:100%;">
-    <path d="M0,0 C150,60 350,0 500,60 L500,00 L0,0 Z" style="stroke: none; fill: #f7f7f7;"></path>
-  </svg>
-</div>
-
-<section id="nos-hebergements" style="background-color:#f7f7f7; padding: 80px 20px; color: #111;">
-  <div style="max-width: 1200px; margin: auto;">
-    <h2 style="text-align: center; font-size: 2.2em; margin-bottom: 40px;">Nos Hébergements</h2>
-    <p style="text-align: center; max-width: 800px; margin: 0 auto 60px;">
-      Afin de proposer à nos stagiaires un cadre optimal alliant confort, sécurité et proximité avec les installations sportives,
-      Tennis Impact s'appuie sur des partenariats avec des structures reconnues partout en France.
-      Chaque lieu d’hébergement a été sélectionné pour offrir les meilleures conditions de récupération et de convivialité.
-    </p>
-    <div style="display: flex; flex-wrap: wrap; justify-content: center; gap: 30px; text-align: center;">
-      <!-- Cartouche Hostens -->
-      <div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-        <img src="assets/photos/1.png" alt="Hostens" style="width: 100%; height: 180px; object-fit: cover;">
-        <div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-          <h3 style="margin: 0 0 10px;">Hostens</h3>
-          <p style="font-size: 0.95em;">Un site naturel en pleine forêt pour une immersion sportive et reposante près de Bordeaux.</p>
-          <div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-hostens')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-        </div>
+      <div class="hero__actions">
+        <a class="btn btn--gold" href="reserver.html">Réserver maintenant</a>
+        <a class="hero__link hero__link--light" href="mailto:contact@tennisimpact.fr">
+          Parler à un conseiller
+          <span class="hero__link-icon" aria-hidden="true">↗</span>
+        </a>
       </div>
-      <!-- Cartouche Poitiers -->
-      <div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-        <img src="assets/photos/2.png" alt="CREPS Poitiers" style="width: 100%; height: 180px; object-fit: cover;">
-        <div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-          <h3 style="margin: 0 0 10px;">CREPS Poitiers</h3>
-          <p style="font-size: 0.95em;">Une infrastructure moderne adaptée à l’entraînement de haut niveau et au repos des athlètes.</p>
-          <div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-hostens')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-        </div>
-      </div>
-      <!-- Cartouche Aix-en-Provence -->
-      <div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-        <img src="assets/photos/3.png" alt="CREPS Aix-en-Provence" style="width: 100%; height: 180px; object-fit: cover;">
-        <div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-          <h3 style="margin: 0 0 10px;">CREPS Aix-en-Provence</h3>
-          <p style="font-size: 0.95em;">Cadre ensoleillé avec accès direct aux courts et équipements sportifs de haut standing.</p>
-          <div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-hostens')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-        </div>
-      </div>
-      <!-- Cartouche Toulouse -->
-      <div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-        <img src="assets/photos/4.png" alt="CREPS Toulouse" style="width: 100%; height: 180px; object-fit: cover;">
-        <div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-          <h3 style="margin: 0 0 10px;">CREPS Toulouse</h3>
-          <p style="font-size: 0.95em;">Confort et accessibilité dans un cadre urbain dynamique avec toutes les commodités à proximité.</p>
-          <div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-hostens')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-        </div>
-      </div>
-      <!-- Cartouche La Baule -->
-      <div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-        <img src="assets/photos/5.png" alt="La Baule" style="width: 100%; height: 180px; object-fit: cover;">
-        <div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-          <h3 style="margin: 0 0 10px;">La Baule</h3>
-          <p style="font-size: 0.95em;">Station balnéaire prisée, parfaite pour allier stage de tennis et ambiance bord de mer.</p>
-          <div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-hostens')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-        </div>
-      </div>
-      <!-- Cartouche Cabourg -->
-      <div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-        <img src="assets/photos/6.png" alt="Cabourg" style="width: 100%; height: 180px; object-fit: cover;">
-        <div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-          <h3 style="margin: 0 0 10px;">Cabourg</h3>
-          <p style="font-size: 0.95em;">Un cadre paisible et élégant sur la côte normande, pour une récupération optimale.</p>
-          <div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-hostens')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
+    </section>
+  </main>
 
+  <script>
+    const navToggle = document.getElementById('navToggle');
+    const mainNav = document.getElementById('mainNav');
 
+    navToggle?.addEventListener('click', () => {
+      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+      navToggle.setAttribute('aria-expanded', String(!expanded));
+      mainNav.classList.toggle('is-open');
+      document.body.classList.toggle('no-scroll', !expanded);
+    });
 
-
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<!-- POPUPS -->
-
-
-
-
-
-
-
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-
-
-
-
-<div id="popup-hostens" class="popup-hebergement">
-  <div class="popup-content">
-    <span class="popup-close" onclick="fermerPopup()">&times;</span>
-    <img src="assets/photos/1.png" alt="Stage à Hostens" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;">
-    <h2>Stage à Hostens</h2>
-    <p>Situé au cœur de la forêt des Landes, le site d’Hostens offre un cadre exceptionnel entre lacs et nature. Les stagiaires évoluent sur des terrains en plein air avec un encadrement de qualité.</p>
-    <h3 style="margin-top:20px;">Journée type :</h3>
-    <ul style="text-align:left; max-width: 600px; margin: 10px auto;">
-      <li>8h00 – Petit déjeuner</li>
-      <li>9h00 – Entraînement tennis (technique)</li>
-      <li>11h00 – Préparation physique</li>
-      <li>12h30 – Déjeuner</li>
-      <li>14h00 – Matchs dirigés</li>
-      <li>16h00 – Activité détente / lac</li>
-      <li>19h00 – Dîner & briefing</li>
-    </ul>
-    <button class="btn-ajouter-panier" onclick="ajouterAuPanier('Stage Hostens')">Ajouter au panier</button>
-  </div>
-</div>
-
-</div>
-
-<div id="popup-poitiers" class="popup-hebergement">
-  <div class="popup-content">
-    <span class="popup-close" onclick="fermerPopup()">&times;</span>
-    <img src="assets/photos/2.png" alt="Stage au CREPS de Poitiers" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;">
-    <h2>Stage au CREPS de Poitiers</h2>
-    <p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-  </div>
-</div>
-
-<div id="popup-aix" class="popup-hebergement">
-  <div class="popup-content">
-    <span class="popup-close" onclick="fermerPopup()">&times;</span>
-    <img src="assets/photos/3.png" alt="Stage au CREPS d’Aix-en-Provence" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;">
-    <h2>Stage au CREPS d’Aix-en-Provence</h2>
-    <p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-  </div>
-</div>
-
-<div id="popup-toulouse" class="popup-hebergement">
-  <div class="popup-content">
-    <span class="popup-close" onclick="fermerPopup()">&times;</span>
-    <img src="assets/photos/4.png" alt="Stage au CREPS de Toulouse" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;">
-    <h2>Stage au CREPS de Toulouse</h2>
-    <p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-  </div>
-</div>
-
-<div id="popup-baule" class="popup-hebergement">
-  <div class="popup-content">
-    <span class="popup-close" onclick="fermerPopup()">&times;</span>
-    <img src="assets/photos/5.png" alt="Stage à La Baule" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;">
-    <h2>Stage à La Baule</h2>
-    <p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-  </div>
-</div>
-
-<div id="popup-cabourg" class="popup-hebergement">
-  <div class="popup-content">
-    <span class="popup-close" onclick="fermerPopup()">&times;</span>
-    <img src="assets/photos/6.png" alt="Stage à Cabourg" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;">
-    <h2>Stage à Cabourg</h2>
-    <p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-  </div>
-</div>
-
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-<script>
-function ouvrirPopup(id) {
-  document.querySelectorAll('.popup-hebergement').forEach(p => p.style.display = 'none');
-  const el = document.getElementById(id);
-  if (el) el.style.display = 'flex';
-}
-function fermerPopup() {
-  document.querySelectorAll('.popup-hebergement').forEach(p => p.style.display = 'none');
-}
-</script>
-
+    mainNav?.querySelectorAll('a, button').forEach(link => {
+      link.addEventListener('click', () => {
+        if (mainNav.classList.contains('is-open')) {
+          mainNav.classList.remove('is-open');
+          document.body.classList.remove('no-scroll');
+          navToggle?.setAttribute('aria-expanded', 'false');
+        }
+      });
+    });
+  </script>
 </body>
 </html>
-
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-
-
-<!-- POPUPS INDIVIDUELS PAR LIEU -->
-
-
-
-
-
-
-
-
-
-
-
-
-<!-- POPUP HOSTENS -->
-<div id="popup-hostens" class="popup-overlay" style="display:none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.75); z-index: 1000; justify-content: center; align-items: center;">
-  <div class="popup-content" style="background: white; max-width: 900px; width: 90%; border-radius: 15px; overflow: hidden; position: relative; animation: fadeIn 0.4s ease;">
-    <span onclick="closePopup('popup-hostens')" style="position: absolute; top: 15px; right: 20px; font-size: 24px; cursor: pointer;">&times;</span>
-    <div style="display: flex; flex-direction: column;">
-      <img src="assets/photos/1.png" alt="Hostens" style="width: 100%; height: 300px; object-fit: cover;">
-      <div style="padding: 30px;">
-        <h2 style="margin-top: 0;">Stage à Hostens</h2>
-        <p><strong>Un site naturel en pleine forêt pour une immersion sportive et reposante près de Bordeaux.</strong></p>
-        <p><em>Plus que 8 places disponibles</em></p>
-        <p style="font-size: 1.2em; font-weight: bold;">1600 € <span style="font-size: 0.8em; font-weight: normal;">*Prix sans hébergement</span></p>
-        <h3>Description</h3>
-        <p>Le site d’Hostens, situé dans une réserve naturelle, offre un cadre exceptionnel pour une pratique intensive du tennis. Les infrastructures sportives sont à proximité immédiate du centre d’hébergement, garantissant confort, sécurité et efficacité dans les déplacements.</p>
-        <h3>Une journée type :</h3>
-        <ul>
-          <li>7h30 : Réveil & petit-déjeuner</li>
-          <li>9h00 - 12h00 : Entraînement tennis + préparation physique</li>
-          <li>12h30 : Déjeuner & temps calme</li>
-          <li>14h30 - 17h00 : Tennis, matchs, coaching mental</li>
-          <li>18h00 : Activité détente (lac, forêt, vélo)</li>
-          <li>20h00 : Dîner & briefing du lendemain</li>
-        </ul>
-        <h3>Prestations incluses :</h3>
-        <ul>
-          <li>Encadrement par coachs diplômés</li>
-          <li>Analyse vidéo & coaching personnalisé</li>
-          <li>Accès aux infrastructures sportives</li>
-          <li>Maillot Tennis Impact offert</li>
-        </ul>
-        <button style="margin-top: 20px; padding: 12px 24px; background: #000; color: #fff; border: none; border-radius: 25px; font-size: 1em; cursor: pointer;">Ajouter ce stage</button>
-      </div>
-    </div>
-  </div>
-</div>
-
-<script>
-function openPopup(id) {
-  document.getElementById(id).style.display = "flex";
-}
-function closePopup(id) {
-  document.getElementById(id).style.display = "none";
-}
-window.addEventListener('click', function(e) {
-  const popup = document.getElementById('popup-hostens');
-  if (e.target === popup) closePopup('popup-hostens');
-});
-</script>

--- a/stages_jeunes.html
+++ b/stages_jeunes.html
@@ -1,1253 +1,358 @@
-
 <!DOCTYPE html>
-
 <html lang="fr">
 <head>
-
-<style>
-.bouton-retour-fixe {
-  position: fixed !important;
-  top: 20px;
-  left: 20px;
-  background-color: #c9a33c;
-  color: white;
-  padding: 12px 20px;
-  font-size: 0.95em;
-  border-radius: 30px;
-  text-decoration: none;
-  z-index: 99999 !important;
-  box-shadow: 0 4px 10px rgba(0,0,0,0.15);
-  transition: background 0.3s ease;
-}
-.bouton-retour-fixe:hover {
-  background-color: #b08e2c;
-}
-</style>
-
-<meta charset="utf-8"/>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Réserver un Stage - Tennis Impact</title>
-<link href="style.css" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Playfair+Display&amp;family=Poppins:wght@300;400;600&amp;display=swap" rel="stylesheet"/>
-<style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Stages jeunes – Tennis Impact</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
     body {
-      font-family: 'Poppins', sans-serif;
-      background-color: #0d0d1f;
-      color: #fff;
-      margin: 0;
-      padding: 0;
+      background: #f6f7fb;
+      color: var(--color-navy);
     }
-    .container {
-  display: grid;
-  grid-template-columns: 2fr 1fr;
-  align-items: start;
-  gap: 40px;
-  min-height: 100vh;
+
+    .stage-hero {
+      position: relative;
+      padding: 130px 0 90px;
+      background: linear-gradient(115deg, rgba(5, 10, 15, 0.85), rgba(13, 27, 42, 0.85)),
+        url('https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=1800&q=80') center/cover;
+      color: var(--color-white);
+    }
+
+    .stage-hero h1 {
+      font-family: var(--font-heading);
+      font-size: clamp(2.5rem, 4vw, 3.4rem);
+      margin-bottom: 1rem;
+    }
+
+    .stage-hero p {
+      max-width: 700px;
+      font-size: 1.1rem;
+      margin-bottom: 2rem;
+    }
+
+    .stage-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+      margin-top: 3rem;
+    }
 
     .stage-card {
-      background: white;
-      color: black;
-      border-radius: 20px;
+      background: var(--color-white);
+      border-radius: var(--radius-card);
+      box-shadow: var(--shadow-soft);
       overflow: hidden;
-      box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-      margin-bottom: 30px;
-      max-width: 500px;
+      display: flex;
+      flex-direction: column;
+      transition: transform var(--transition-base), box-shadow var(--transition-base);
     }
+
+    .stage-card:hover {
+      transform: translateY(-6px);
+      box-shadow: var(--shadow-strong);
+    }
+
     .stage-card img {
-      width: 100%;
-      height: auto;
+      height: 210px;
+      object-fit: cover;
     }
-    .stage-card .content {
-      padding: 20px;
+
+    .stage-card .card__body {
+      padding: 1.8rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.9rem;
     }
-    .stage-card h3 {
-      font-family: 'Playfair Display', serif;
-      margin-top: 0;
-      color: #0d0d1f;
-    }
-    .stage-card .price {
-      font-weight: bold;
-      color: #b28d00;
-    }
+
     .stage-card ul {
-      padding-left: 20px;
+      list-style: disc;
+      padding-left: 1.2rem;
+      color: var(--color-grey-600);
+      line-height: 1.5;
     }
-    .stage-card button {
-      background-color: #0d0d1f;
-      color: white;
-      border: none;
-      padding: 12px 20px;
-      border-radius: 10px;
-      cursor: pointer;
-      margin-top: 15px;
+
+    .location-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1.8rem;
+      margin-top: 3rem;
     }
-    .cart {
-  position: -webkit-sticky;
-  position: sticky;
-  top: 40px;
-  align-self: start;
-  background: #1a1a2e;
-  border-radius: 20px;
-  padding: 30px;
-  box-shadow: 0 4px 20px rgba(255, 215, 0, 0.2);
-  min-width: 300px;
-  color: white;
-}
-    .cart h2 {
-      color: #fdd835;
-      font-family: 'Playfair Display', serif;
+
+    .location-card {
+      border-radius: var(--radius-card);
+      background: var(--color-white);
+      overflow: hidden;
+      box-shadow: var(--shadow-soft);
+      display: flex;
+      flex-direction: column;
     }
-    .cart-item {
-      background: #111;
-      margin-bottom: 15px;
-      padding: 15px;
-      border-radius: 10px;
+
+    .location-card img {
+      height: 200px;
+      object-fit: cover;
     }
-    .cart-item span {
-      display: block;
+
+    .location-card .card__body {
+      padding: 1.6rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
     }
-    .cart button {
-      width: 100%;
-      background-color: #fdd835;
-      color: #0d0d1f;
-      font-weight: bold;
-      padding: 15px;
-      border: none;
-      border-radius: 12px;
-      cursor: pointer;
-      margin-top: 20px;
+
+    .timeline {
+      display: grid;
+      gap: 1rem;
+      margin-top: 2rem;
     }
-  
-.premium-form {
-  background: #ffffff;
-  border: 2px solid #fdd835;
-  box-shadow: 0 0 40px rgba(255, 215, 0, 0.25);
-  border-radius: 20px;
-  padding: 40px;
-  font-family: 'Poppins', sans-serif;
-  color: #0d0d1f;
-}
-.premium-form h2 {
-  font-family: 'Playfair Display', serif;
-  font-size: 28px;
-  color: #0d0d1f;
-}
-.premium-form input,
-.premium-form select {
-  width: 100%;
-  margin-bottom: 15px;
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px solid #ccc;
-}
-.premium-form button[type='submit'] {
-  background-color: #0d0d1f;
-  color: #fdd835;
-  font-weight: bold;
-  padding: 12px 20px;
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-}
-.premium-form button[type='button'] {
-  background-color: #bbb;
-  color: white;
-  margin-left: 10px;
-  padding: 12px 20px;
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-}
 
+    .timeline-step {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 1rem;
+      align-items: flex-start;
+      background: rgba(5, 10, 15, 0.04);
+      padding: 1.4rem;
+      border-radius: var(--radius-card);
+    }
 
-.stages {
-  padding-right: 20px;
-  border-right: 1px solid rgba(255, 255, 255, 0.1);
-}
-.cart {
-  padding-left: 30px;
-  background: #12122a;
-}
+    .timeline-step strong {
+      font-size: 1.5rem;
+      color: var(--color-gold-dark);
+    }
 
+    .cta-banner {
+      margin: 5rem 0 3rem;
+      background: linear-gradient(120deg, rgba(249, 214, 92, 0.95), rgba(217, 166, 0, 0.95));
+      border-radius: var(--radius-large);
+      padding: clamp(2.5rem, 5vw, 4rem);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+      text-align: center;
+      box-shadow: var(--shadow-soft);
+    }
 
-@keyframes fadeZoomIn {
-  0% { opacity: 0; transform: scale(0.8) translate(-50%, -50%); }
-  100% { opacity: 1; transform: scale(1) translate(-50%, -50%); }
-}
-#form-popup {
-  animation: fadeZoomIn 0.4s ease-out;
-}
-
-
-.stage-card {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  background: white;
-  color: black;
-  border-radius: 20px;
-  overflow: hidden;
-  box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-  margin-bottom: 30px;
-  max-width: 100%;
-}
-.stage-card img {
-  width: 300px;
-  height: auto;
-  object-fit: cover;
-}
-.stage-card .content {
-  padding: 20px;
-  flex: 1;
-}
-
-</style>
-<script>
-function openForm(stageName) {
-  const popup = document.getElementById("form-popup");
-  const input = popup.querySelector("input[name='stage'], select[name='stage']");
-  if (input) input.value = stageName;
-  popup.style.display = "block";
-}
-
-function closeForm() {
-  document.getElementById("form-popup").style.display = "none";
-}
-
-// Simulation d'envoi avec fermeture automatique
-document.addEventListener("DOMContentLoaded", function () {
-  const form = document.querySelector("#form-popup form");
-  if (form) {
-    form.addEventListener("submit", function (e) {
-      e.preventDefault();
-      console.log("Formulaire soumis. Simulation EmailJS.");
-      // Remplace ce bloc par EmailJS.send(...) plus tard
-      setTimeout(() => {
-        alert("Formulaire envoyé !");
-        closeForm();
-      }, 1000);
-    });
-  }
-});
-</script>
-
-<style>
-.popup {
-  display: none;
-  position: fixed;
-  z-index: 9999;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  background: rgba(0,0,0,0.7);
-  overflow-y: auto;
-}
-.popup-content {
-  background: #fff;
-  margin: 5% auto;
-  padding: 30px;
-  border-radius: 16px;
-  max-width: 800px;
-  position: relative;
-  font-family: 'Poppins', sans-serif;
-  box-shadow: 0 0 20px rgba(0,0,0,0.4);
-}
-.popup-content h2 {
-  margin-top: 0;
-  font-size: 1.8em;
-  text-align: center;
-  border-bottom: 1px solid #ddd;
-  padding-bottom: 10px;
-}
-.popup-images img {
-  width: 100%;
-  border-radius: 12px;
-  margin-bottom: 15px;
-  max-height: 300px;
-  object-fit: cover;
-}
-.popup-text {
-  font-size: 1em;
-  color: #222;
-  line-height: 1.6;
-}
-.popup-text ul {
-  padding-left: 20px;
-  list-style-type: disc;
-}
-.popup .close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 28px;
-  color: #555;
-  cursor: pointer;
-}
-</style>
-
+    .cta-banner p {
+      max-width: 680px;
+      color: rgba(5, 10, 15, 0.75);
+    }
+  </style>
 </head>
 <body>
+  <header class="navbar">
+    <div class="navbar__container">
+      <a class="navbar__brand" href="index.html" aria-label="Retour à l'accueil Tennis Impact">
+        <img src="assets/images/logo.svg" alt="Tennis Impact" />
+      </a>
+      <button class="navbar__toggle" id="navToggle" aria-expanded="false" aria-controls="mainNav" aria-label="Ouvrir le menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <nav class="navbar__links" id="mainNav" aria-label="Navigation principale">
+        <ul class="navbar__menu">
+          <li><a href="index.html#academie" class="nav-link">Notre académie</a></li>
+          <li>
+            <a href="stages_jeunes.html" class="nav-link" aria-current="page">Stages jeunes</a>
+          </li>
+          <li><a href="lecon_individuelle.html" class="nav-link">Leçons individuelles</a></li>
+          <li><a href="espace_coach.html" class="nav-link">Espace coach</a></li>
+          <li><a href="reserver.html" class="nav-link">Réserver un stage</a></li>
+          <li><a href="mailto:contact@tennisimpact.fr" class="nav-link nav-link--cta">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
 
-<a href="index.html" style="position: fixed; top: 20px; left: 20px; background-color: #c9a33c; color: white; padding: 12px 20px; font-size: 0.95em; border-radius: 30px; text-decoration: none; z-index: 999999; box-shadow: 0 4px 10px rgba(0,0,0,0.15); transition: background 0.3s ease;">← Retour à l’accueil</a>
+  <main>
+    <section class="stage-hero">
+      <div class="container">
+        <p class="hero__subtitle">Immersion haute intensité</p>
+        <h1>Stages jeunes Tennis Impact</h1>
+        <p>Des programmes premium pour révéler les talents de 8 à 18 ans. Coaching d’excellence, préparation physique, suivi mental et moments de cohésion inoubliables.</p>
+        <div class="hero__actions">
+          <a class="btn btn--gold" href="reserver.html">Réserver un stage</a>
+          <a class="hero__link hero__link--light" href="#programme">
+            Découvrir les formats
+            <span class="hero__link-icon" aria-hidden="true">↗</span>
+          </a>
+        </div>
+      </div>
+    </section>
 
+    <section class="section" id="programme">
+      <div class="container">
+        <span class="eyebrow">Nos formats signature</span>
+        <h2>Un stage adapté au profil de chaque joueur</h2>
+        <div class="stage-grid">
+          <article class="stage-card">
+            <img src="https://images.unsplash.com/photo-1503185912284-5271ff81b9a8?auto=format&fit=crop&w=1200&q=80" alt="Stage intensif Tennis Impact" />
+            <div class="card__body">
+              <h3>Stage Intensif Performance</h3>
+              <p><strong>1 semaine • 2 entraînements / jour</strong></p>
+              <ul>
+                <li>Analyse vidéo quotidienne et coaching mental.</li>
+                <li>Préparation physique ciblée + récupération.</li>
+                <li>Rapport individualisé et plan d’objectifs.</li>
+              </ul>
+              <a class="btn btn--outline" href="reserver.html">Je réserve</a>
+            </div>
+          </article>
+          <article class="stage-card">
+            <img src="https://images.unsplash.com/photo-1527490087278-9c75becc5a5d?auto=format&fit=crop&w=1200&q=80" alt="Stage multisport Tennis Impact" />
+            <div class="card__body">
+              <h3>Stage Multisport Excellence</h3>
+              <p><strong>5 jours • Tennis &amp; activités complémentaires</strong></p>
+              <ul>
+                <li>Ateliers tactiques, team building et nutrition.</li>
+                <li>Session mentale quotidienne en petit groupe.</li>
+                <li>Option hébergement premium sur site.</li>
+              </ul>
+              <a class="btn btn--outline" href="reserver.html">Je réserve</a>
+            </div>
+          </article>
+          <article class="stage-card">
+            <img src="https://images.unsplash.com/photo-1517486808906-6ca8b3f04846?auto=format&fit=crop&w=1200&q=80" alt="Stage compétition Tennis Impact" />
+            <div class="card__body">
+              <h3>Tournée &amp; Coaching Tournois</h3>
+              <p><strong>10 jours • Tournois FFT &amp; UTR</strong></p>
+              <ul>
+                <li>Accompagnement complet sur chaque match.</li>
+                <li>Préparation mentale et routines d’avant match.</li>
+                <li>Débriefing stratégique quotidien.</li>
+              </ul>
+              <a class="btn btn--outline" href="reserver.html">Je réserve</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
 
-<a href="index.html" onmouseout="this.style.backgroundColor='#c9a33c'" onmouseover="this.style.backgroundColor='#b08e2c'" style="
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  background-color: #c9a33c;
-  color: white;
-  padding: 12px 20px;
-  font-size: 0.95em;
-  border-radius: 30px;
-  text-decoration: none;
-  z-index: 1000;
-  box-shadow: 0 4px 10px rgba(0,0,0,0.15);
-  transition: background 0.3s ease;
-">
-← Retour à l’accueil
-</a>
+    <section class="section section--dark" id="destinations">
+      <div class="container">
+        <div class="section__intro">
+          <span class="eyebrow eyebrow--light">Destinations premium</span>
+          <h2>Des cadres inspirants pour performer</h2>
+          <p>Nos partenaires nous permettent d’accueillir vos enfants sur des sites d’exception en France.</p>
+        </div>
+        <div class="location-grid">
+          <article class="location-card">
+            <img src="https://images.unsplash.com/photo-1521412644187-c49fa049e84d?auto=format&fit=crop&w=1200&q=80" alt="Hostens" />
+            <div class="card__body">
+              <h3>Hostens • Nature &amp; sérénité</h3>
+              <p>En plein cœur des Landes, idéal pour allier intensité et récupération au bord du lac.</p>
+              <p><strong>Points forts :</strong> hébergement premium &amp; activités outdoor.</p>
+            </div>
+          </article>
+          <article class="location-card">
+            <img src="https://images.unsplash.com/photo-1544322435-5b07c1309b20?auto=format&fit=crop&w=1200&q=80" alt="CREPS Poitiers" />
+            <div class="card__body">
+              <h3>Poitiers • CREPS Haute Performance</h3>
+              <p>Complexe indoor/outdoor, staff médical et espaces de récupération à disposition.</p>
+              <p><strong>Points forts :</strong> suivi scientifique &amp; tournoi Futuroscope.</p>
+            </div>
+          </article>
+          <article class="location-card">
+            <img src="https://images.unsplash.com/photo-1560582861-45078880e48e?auto=format&fit=crop&w=1200&q=80" alt="Aix-en-Provence" />
+            <div class="card__body">
+              <h3>Aix-en-Provence • Soleil &amp; intensité</h3>
+              <p>Climat idéal, surfaces variées, immersion totale pour viser la compétition.</p>
+              <p><strong>Points forts :</strong> programme double tennis &amp; français.</p>
+            </div>
+          </article>
+          <article class="location-card">
+            <img src="https://images.unsplash.com/photo-1518081461904-9d8f136351c8?auto=format&fit=crop&w=1200&q=80" alt="Cabourg" />
+            <div class="card__body">
+              <h3>Cabourg • Littoral élite</h3>
+              <p>Atmosphère bord de mer pour conjuguer exigence sportive et moment détente.</p>
+              <p><strong>Points forts :</strong> sessions night sessions &amp; golf.</p>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
 
-<a href="index.html" style="
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  background-color: #c9a33c;
-  color: white;
-  padding: 12px 20px;
-  font-size: 0.95em;
-  border-radius: 30px;
-  text-decoration: none;
-  z-index: 10000;
-  box-shadow: 0 4px 10px rgba(0,0,0,0.15);
-  transition: background 0.3s ease;
-" onmouseover="this.style.backgroundColor='#b08e2c'" onmouseout="this.style.backgroundColor='#c9a33c'">
-← Retour à l’accueil
-</a>
+    <section class="section" id="experience">
+      <div class="container section__grid">
+        <div class="section__content">
+          <span class="eyebrow">Une journée type</span>
+          <h2>Un rythme structuré pour maximiser la progression</h2>
+          <p>Chaque stage suit un fil conducteur précis et adapté au profil du joueur pour garantir une progression tangible.</p>
+          <div class="timeline">
+            <div class="timeline-step">
+              <strong>08h30</strong>
+              <div>
+                <h3>Échauffement collectif</h3>
+                <p>Mobilité, appuis et activation avec notre préparateur physique.</p>
+              </div>
+            </div>
+            <div class="timeline-step">
+              <strong>10h00</strong>
+              <div>
+                <h3>Bloc technique &amp; tactique</h3>
+                <p>Ateliers ciblés, travail vidéo et routines individuelles.</p>
+              </div>
+            </div>
+            <div class="timeline-step">
+              <strong>14h00</strong>
+              <div>
+                <h3>Matchs dirigés</h3>
+                <p>Situations de compétition coachées avec retours en direct.</p>
+              </div>
+            </div>
+            <div class="timeline-step">
+              <strong>17h00</strong>
+              <div>
+                <h3>Récupération &amp; mental</h3>
+                <p>Débriefing, préparation mentale, cryothérapie ou ateliers bien-être.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="section__visual">
+          <img src="assets/images/stage-2.svg" alt="Illustration stage tennis" />
+        </div>
+      </div>
+    </section>
 
-<section style="position: relative; width: 100%; height: 100vh; background: url('assets/photos/3.png') center/cover no-repeat; display: flex; align-items: center; justify-content: center;">
-<div style="background-color: rgba(0,0,0,0.55); padding: 40px; border-radius: 12px; color: white; text-align: center;">
-<h1 style="font-size: 2.5rem; margin: 0;">Réservez votre stage</h1>
-<h2 style="font-size: 1.6rem; font-weight: 300;">Choisissez vos dates et options d’hébergement</h2>
-<p style="margin-top: 10px; font-size: 1rem;">Académie Tennis Impact</p>
-</div>
-</section>
-<nav style="position: sticky; top: 0; z-index: 1000; background: white; border-bottom: 2px solid #eee; padding: 12px 20px; display: flex; justify-content: center; gap: 30px; font-weight: bold;">
-<a href="#stages" style="color: #001f3f; text-decoration: none;">Stages</a>
-<a href="#methode" style="color: #001f3f; text-decoration: none;">Méthodologie</a>
-<a href="reserver.html#nos-hebergements" style="color: #001f3f; text-decoration: none;">Nos Hébergements</a>
-<a href="#options" style="color: #001f3f; text-decoration: none;">Options</a>
-<a href="#faq" style="color: #001f3f; text-decoration: none;">FAQ</a>
-</nav>
-<section style="width: 100%; background-color: white; padding: 100px 20px 120px; position: relative;">
-<div style="max-width: 1000px; margin: auto; text-align: center;">
-<h2 style="color: #001f3f; font-size: 2.5rem; margin-bottom: 20px;">
-      Des stages tennis jeunes au cœur de la Côte d’Azur
-    </h2>
-<h3 style="color: #FFD700; font-size: 1.6rem; font-weight: bold; margin-bottom: 30px;">
-      OFFREZ À VOTRE ENFANT L’EXCELLENCE TENNIS IMPACT
-    </h3>
-<p style="font-size: 1.2rem; color: #333; line-height: 1.8;">
-      Chaque année, Tennis Impact accueille de nombreux jeunes joueurs venus de toute la France pour vivre une expérience unique alliant sport de haut niveau, développement personnel et plaisir du jeu.<br/><br/>
-      Nos stages de tennis pour jeunes sont conçus pour s’adapter à tous les profils : du joueur loisir au compétiteur ambitieux. Dans un environnement structuré, dynamique et bienveillant, votre enfant progresse à son rythme tout en découvrant les exigences du haut niveau.
-    </p>
-</div>
-<!-- Vague de séparation corrigée -->
-<div style="position: absolute; bottom: 0; left: 0; width: 100%; overflow: hidden; line-height: 0;">
-<svg preserveaspectratio="none" style="display: block; width: 100%; height: 70px;" viewbox="0 0 500 50">
-<path d="M0,30 C150,80 350,-10 500,30 L500,00 L0,0 Z" style="fill:#001f3f;"></path>
-</svg>
-</div>
-</section>
-<div class="container">
-<div class="stages">
-<div class="stage-card">
-<img alt="Stage INTENSIF" src="assets/photos/1.png"/>
-<div class="content">
-<h3>Stage INTENSIF</h3>
-<p>Journée entière • 23 juin - 28 juin</p>
-<p class="price">1 600,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>2 sessions de tennis en groupe par jour</li><li>3h d'activité physique</li><li>Rapport individuel</li><li>Repas du midi</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage COMPÉTITION" src="assets/photos/2.png"/>
-<div class="content">
-<h3>Stage COMPÉTITION</h3>
-<p>Journée entière • 23 juin - 05 juil.</p>
-<p class="price">4 200,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>2 sessions de tennis</li><li>Tournoi UTR inclus</li><li>Préparation mentale</li><li>Rapport individuel</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage DEMI-JOURNÉE" src="assets/photos/3.png"/>
-<div class="content">
-<h3>Stage DEMI-JOURNÉE</h3>
-<p>Demi journée • 23 juin - 28 juin</p>
-<p class="price">1 050,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>1 session de tennis</li><li>Rapport individuel</li><li>Matinée uniquement</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage INTENSIF + Français" src="assets/photos/4.png"/>
-<div class="content">
-<h3>Stage INTENSIF + Français</h3>
-<p>Journée entière • 30 juin - 05 juil.</p>
-<p class="price">1 750,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>Tennis + Français</li><li>1h30 de physique/jour</li><li>Repas du midi</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage TENNIS &amp; GOLF" src="assets/photos/5.png"/>
-<div class="content">
-<h3>Stage TENNIS &amp; GOLF</h3>
-<p>Journée entière • 30 juin - 05 juil.</p>
-<p class="price">1 700,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>Tennis le matin</li><li>Golf l’après-midi</li><li>Repas du midi</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-<div class="stage-card">
-<img alt="Stage NIGHT SESSIONS" src="assets/photos/6.png"/>
-<div class="content">
-<h3>Stage NIGHT SESSIONS</h3>
-<p>Soir • 30 juin - 04 juil.</p>
-<p class="price">900,00 € <span style="font-weight: normal;">*Sans hébergement</span></p>
-<ul>
-<li>Sessions du soir</li><li>Cardio tennis</li><li>Welcome pack</li>
-</ul>
-<button onclick="openForm('Stage INTENSIF')">Ajouter ce stage</button>
-</div>
-</div>
-</div>
-<div class="cart">
-<h2>Mon Panier</h2>
-<div class="cart-item">
-<span><strong>Stage INTENSIF</strong></span>
-<span>23 juin - 28 juin</span>
-<span>1 600,00 €</span>
-</div>
-<button onclick="openForm('Panier')">Valider l’inscription</button>
-</div>
-</div>
-<div id="form-popup" style="display: none; position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; padding: 40px; border-radius: 20px; z-index: 1000; max-width: 800px; width: 90%; max-height: 90vh; overflow-y: auto; font-family: Poppins, sans-serif;">
-<div style="display: flex; justify-content: space-between; align-items: center;">
-<h2 style="margin-top: 0; color: #0d0d1f;">Inscription au Stage</h2>
-<button onclick="closeForm()" style="background-color: #bbb; padding: 5px 10px; border: none; border-radius: 8px;">X</button>
-</div>
-<form>
-<div class="form-grid">
-<label for="lieu">
-     Lieu du stage
-    </label>
-<select id="lieu" name="lieu">
-<option value="Paris">
-      Paris
-     </option>
-<option value="Colmar">
-      Colmar
-     </option>
-</select>
-<label for="type_stage">
-     Type de stage
-    </label>
-<select id="type_stage" name="type_stage">
-<option value="Intensif">
-      Intensif
-     </option>
-<option value="Demi-journée">
-      Demi-journée
-     </option>
-<option value="Compétition">
-      Compétition
-     </option>
-</select>
-<div class="form-field">
-<label for="prenom">
-      Prénom
-     </label>
-</div>
-<div class="form-field">
-<input id="prenom" name="prenom" required="" type="text"/>
-</div>
-<div class="form-field">
-<label for="nom">
-      Nom
-     </label>
-</div>
-<div class="form-field">
-<input id="nom" name="nom" required="" type="text"/>
-</div>
-<div class="form-field">
-<label for="niveau">
-      Niveau FFT
-     </label>
-</div>
-<div class="form-field">
-<select id="niveau" name="niveau">
-<option value="">
-       -- Sélectionnez --
-      </option>
-<option>
-       Blanc
-      </option>
-<option>
-       Violet
-      </option>
-<option>
-       Rouge
-      </option>
-<option>
-       Orange
-      </option>
-<option>
-       Vert
-      </option>
-<option>
-       Jaune
-      </option>
-<option>
-       40
-      </option>
-<option>
-       30/5
-      </option>
-<option>
-       30/4
-      </option>
-<option>
-       30/3
-      </option>
-<option>
-       30/2
-      </option>
-<option>
-       30/1
-      </option>
-<option>
-       30
-      </option>
-<option>
-       15/5
-      </option>
-<option>
-       15/4
-      </option>
-<option>
-       15/3
-      </option>
-<option>
-       15/2
-      </option>
-<option>
-       15/1
-      </option>
-<option>
-       15
-      </option>
-<option>
-       -2/6
-      </option>
-<option>
-       -4/6
-      </option>
-<option>
-       -15
-      </option>
-</select>
-</div>
-<div class="form-field">
-<label for="date">
-      Semaine de Stage
-     </label>
-</div>
-<div class="form-field">
-<input id="date" name="date" required="" type="week"/>
-</div>
-<div class="form-field">
-<label for="hebergement">
-      Souhaitez-vous l’hébergement ?
-     </label>
-</div>
-<div class="form-field">
-<select id="hebergement" name="hebergement">
-<option value="">
-       -- Sélectionnez --
-      </option>
-<option>
-       Oui
-      </option>
-<option>
-       Non
-      </option>
-</select>
-</div>
-</div>
-<button type="submit">
-    Valider l'inscription
-   </button>
-</form>
-</div>
-<script>
-function openForm(stageName) {
-  const popup = document.getElementById("form-popup");
-  const input = popup.querySelector("input[name='stage'], select[name='stage']");
-  if (input) input.value = stageName;
-  popup.style.display = "block";
-}
+      <section class="container cta-banner">
+        <h2>Prêt à vivre l’expérience Tennis Impact ?</h2>
+        <p>Nos conseillers reviennent vers vous sous 24h pour construire un stage sur-mesure et réserver votre hébergement premium.</p>
+        <div class="hero__actions">
+          <a class="btn btn--gold" href="reserver.html">Réserver maintenant</a>
+          <a class="hero__link" href="mailto:contact@tennisimpact.fr">
+            Échanger avec un expert
+            <span class="hero__link-icon" aria-hidden="true">↗</span>
+          </a>
+        </div>
+      </section>
+  </main>
 
-function closeForm() {
-  document.getElementById("form-popup").style.display = "none";
-}
+  <script>
+    const navToggle = document.getElementById('navToggle');
+    const mainNav = document.getElementById('mainNav');
 
-// Simulation d'envoi avec fermeture automatique
-document.addEventListener("DOMContentLoaded", function () {
-  const form = document.querySelector("#form-popup form");
-  if (form) {
-    form.addEventListener("submit", function (e) {
-      e.preventDefault();
-      console.log("Formulaire soumis. Simulation EmailJS.");
-      // Remplace ce bloc par EmailJS.send(...) plus tard
-      setTimeout(() => {
-        alert("Formulaire envoyé !");
-        closeForm();
-      }, 1000);
+    navToggle?.addEventListener('click', () => {
+      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+      navToggle.setAttribute('aria-expanded', String(!expanded));
+      mainNav.classList.toggle('is-open');
+      document.body.classList.toggle('no-scroll', !expanded);
     });
-  }
-});
-</script>
-<section class="methodologie" id="methodologie" style="background:#ffffff; color:#111; padding: 80px 20px; margin-top: 80px;">
-<div data-aos="fade-up" style="max-width: 1200px; margin: auto; display: flex; flex-wrap: wrap; align-items: center; gap: 40px;">
-<div style="flex: 1 1 500px;">
-<h2 style="font-size: 2em; margin-bottom: 20px; color: #000;">Notre Méthodologie</h2>
-<p style="margin-bottom: 20px;">
-        À Tennis Impact, nous croyons qu’il n’existe pas de méthode unique. Chaque joueur est unique et mérite une approche personnalisée, en accord avec sa personnalité, ses besoins et ses objectifs. 
-        C’est pourquoi notre méthodologie repose sur cinq piliers fondamentaux :
-      </p>
-<ul style="list-style-type: none; padding: 0;">
-<li><strong>Écoute :</strong> Comprendre profondément chaque athlète, au-delà des mots.</li>
-<li><strong>Coaching individualisé :</strong> Construire des programmes d’entraînement adaptés aux besoins spécifiques de chacun.</li>
-<li><strong>Poursuite de l’excellence :</strong> Viser toujours plus haut, repousser les limites, et ne jamais se satisfaire de l’acquis.</li>
-<li><strong>Culture du résultat :</strong> Se concentrer sur des performances tangibles, sur et en dehors du court.</li>
-<li><strong>Remise en question permanente :</strong> Innover sans cesse pour progresser chaque jour.</li>
-</ul>
-</div>
-<div style="flex: 1 1 400px; text-align: center;">
-<img alt="Méthodologie Tennis" src="assets/photos/6.png" style="max-width: 100%; border-radius: 12px;"/>
-</div>
-</div>
-</section>
-<div style="width:100%; overflow:hidden; line-height:0; margin-top: -1px;">
-<svg preserveaspectratio="none" style="height:60px; width:100%;" viewbox="0 0 500 60">
-<path d="M0,0 C150,60 350,0 500,60 L500,00 L0,0 Z" style="stroke: none; fill: #f7f7f7;"></path>
-</svg>
-</div>
-<section id="nos-hebergements" style="background-color:#f7f7f7; padding: 80px 20px; color: #111;">
-<div style="max-width: 1200px; margin: auto;">
-<h2 style="text-align: center; font-size: 2.2em; margin-bottom: 40px;">Nos Hébergements</h2>
-<p style="text-align: center; max-width: 800px; margin: 0 auto 60px;">
-      Afin de proposer à nos stagiaires un cadre optimal alliant confort, sécurité et proximité avec les installations sportives,
-      Tennis Impact s'appuie sur des partenariats avec des structures reconnues partout en France.
-      Chaque lieu d’hébergement a été sélectionné pour offrir les meilleures conditions de récupération et de convivialité.
-    </p>
-<div style="display: flex; flex-wrap: wrap; justify-content: center; gap: 30px; text-align: center;">
-<!-- Cartouche Hostens -->
-<div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-<img alt="Hostens" src="assets/photos/1.png" style="width: 100%; height: 180px; object-fit: cover;"/>
-<div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-<h3 style="margin: 0 0 10px;">Hostens</h3>
-<p style="font-size: 0.95em;">Un site naturel en pleine forêt pour une immersion sportive et reposante près de Bordeaux.</p>
-<div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-poitiers')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-</div>
-</div>
-<!-- Cartouche Poitiers -->
-<div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-<img alt="CREPS Poitiers" src="assets/photos/2.png" style="width: 100%; height: 180px; object-fit: cover;"/>
-<div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-<h3 style="margin: 0 0 10px;">CREPS Poitiers</h3>
-<p style="font-size: 0.95em;">Une infrastructure moderne adaptée à l’entraînement de haut niveau et au repos des athlètes.</p>
-<div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-toulouse')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-</div>
-</div>
-<!-- Cartouche Aix-en-Provence -->
-<div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-<img alt="CREPS Aix-en-Provence" src="assets/photos/3.png" style="width: 100%; height: 180px; object-fit: cover;"/>
-<div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-<h3 style="margin: 0 0 10px;">CREPS Aix-en-Provence</h3>
-<p style="font-size: 0.95em;">Cadre ensoleillé avec accès direct aux courts et équipements sportifs de haut standing.</p>
-<div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-aix')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-</div>
-</div>
-<!-- Cartouche Toulouse -->
-<div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-<img alt="CREPS Toulouse" src="assets/photos/4.png" style="width: 100%; height: 180px; object-fit: cover;"/>
-<div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-<h3 style="margin: 0 0 10px;">CREPS Toulouse</h3>
-<p style="font-size: 0.95em;">Confort et accessibilité dans un cadre urbain dynamique avec toutes les commodités à proximité.</p>
-<div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-cabourg')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-</div>
-</div>
-<!-- Cartouche La Baule -->
-<div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-<img alt="La Baule" src="assets/photos/5.png" style="width: 100%; height: 180px; object-fit: cover;"/>
-<div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-<h3 style="margin: 0 0 10px;">La Baule</h3>
-<p style="font-size: 0.95em;">Station balnéaire prisée, parfaite pour allier stage de tennis et ambiance bord de mer.</p>
-<div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-hostens')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-</div>
-</div>
-<!-- Cartouche Cabourg -->
-<div style="width: 300px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-<img alt="Cabourg" src="assets/photos/6.png" style="width: 100%; height: 180px; object-fit: cover;"/>
-<div style="padding: 20px; display: flex; flex-direction: column; justify-content: space-between; height: 220px;">
-<h3 style="margin: 0 0 10px;">Cabourg</h3>
-<p style="font-size: 0.95em;">Un cadre paisible et élégant sur la côte normande, pour une récupération optimale.</p>
-<div style="margin-top: auto; text-align: center;"><a onclick="openPopup('popup-hostens')" style="display: inline-block; padding: 8px 18px; border-radius: 25px; background-color: #0a0a0a; color: #fff; text-decoration: none; font-size: 0.9em; cursor: pointer;">En savoir plus</a></div>
-</div>
-</div>
-</div>
-</div>
-</section>
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-<!-- POPUPS -->
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-<div class="popup-hebergement" id="popup-hostens">
-<div class="popup-content">
-<span class="popup-close" onclick="fermerPopup()">×</span>
-<img alt="Stage à Hostens" src="assets/photos/1.png" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;"/>
-<h2>Stage à Hostens</h2>
-<p>Situé au cœur de la forêt des Landes, le site d’Hostens offre un cadre exceptionnel entre lacs et nature. Les stagiaires évoluent sur des terrains en plein air avec un encadrement de qualité.</p>
-<h3 style="margin-top:20px;">Journée type :</h3>
-<ul style="text-align:left; max-width: 600px; margin: 10px auto;">
-<li>8h00 – Petit déjeuner</li>
-<li>9h00 – Entraînement tennis (technique)</li>
-<li>11h00 – Préparation physique</li>
-<li>12h30 – Déjeuner</li>
-<li>14h00 – Matchs dirigés</li>
-<li>16h00 – Activité détente / lac</li>
-<li>19h00 – Dîner &amp; briefing</li>
-</ul>
-<button class="btn-ajouter-panier" onclick="ajouterAuPanier('Stage Hostens')">Ajouter au panier</button>
-</div>
-</div>
 
-<div class="popup-hebergement" id="popup-poitiers">
-<div class="popup-content">
-<span class="popup-close" onclick="fermerPopup()">×</span>
-<img alt="CREPS Poitiers - Vue aérienne" src="assets/photos/creps_poitiers_1.jpg" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;"/>
-<h2>Stage au CREPS de Poitiers</h2>
-<p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-</div>
-</div>
-<div class="popup-hebergement" id="popup-aix">
-<div class="popup-content">
-<span class="popup-close" onclick="fermerPopup()">×</span>
-<img alt="Stage au CREPS d’Aix-en-Provence" src="assets/photos/3.png" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;"/>
-<h2>Stage au CREPS d’Aix-en-Provence</h2>
-<p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-</div>
-</div>
-<div class="popup-hebergement" id="popup-toulouse">
-<div class="popup-content">
-<span class="popup-close" onclick="fermerPopup()">×</span>
-<img alt="Stage au CREPS de Toulouse" src="assets/photos/4.png" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;"/>
-<h2>Stage au CREPS de Toulouse</h2>
-<p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-</div>
-</div>
-<div class="popup-hebergement" id="popup-baule">
-<div class="popup-content">
-<span class="popup-close" onclick="fermerPopup()">×</span>
-<img alt="Stage à La Baule" src="assets/photos/5.png" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;"/>
-<h2>Stage à La Baule</h2>
-<p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-</div>
-</div>
-<div class="popup-hebergement" id="popup-cabourg">
-<div class="popup-content">
-<span class="popup-close" onclick="fermerPopup()">×</span>
-<img alt="Stage à Cabourg" src="assets/photos/6.png" style="width:100%; height:auto; max-height:300px; object-fit:cover; border-radius:12px; margin-bottom:20px;"/>
-<h2>Stage à Cabourg</h2>
-<p>Programme complet : entraînements, hébergement, encadrement dans un cadre idéal.</p>
-</div>
-</div>
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-<script>
-function ouvrirPopup(id) {
-  document.querySelectorAll('.popup-hebergement').forEach(p => p.style.display = 'none');
-  const el = document.getElementById(id);
-  if (el) el.style.display = 'flex';
-}
-function fermerPopup() {
-  document.querySelectorAll('.popup-hebergement').forEach(p => p.style.display = 'none');
-}
-</script>
-
-
-<div id="popup-poitiers" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage Futuroscope - Poitiers</h2>
-    <div class="popup-images"><img src="assets/photos/creps_poitiers_1.jpg" alt="Poitiers" /></div>
-    <div class="popup-text">
-      <p>Le CREPS de Poitiers combine entraînement et découverte culturelle avec une sortie exceptionnelle au Futuroscope.</p>
-      <h3>Journée type :</h3><ul>
-        <li>2 séances tennis</li>
-        <li>Préparation mentale</li>
-        <li>Sortie au Futuroscope</li>
-      </ul>
-    </div>
-  </div>
-</div>
-<div id="popup-toulouse" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage + Cité de l’Espace - Toulouse</h2>
-    <div class="popup-images"><img src="assets/photos/creps toulouse.jpg" alt="Toulouse" /></div>
-    <div class="popup-text">
-      <p>Entraînement complet + sortie exceptionnelle à la Cité de l’Espace.</p>
-      <h3>Journée type :</h3><ul>
-        <li>2 séances tennis / jour</li>
-        <li>Prépa physique & vidéo</li>
-        <li>Sortie découverte scientifique</li>
-      </ul>
-    </div>
-  </div>
-</div>
-<div id="popup-aix" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage intensif - Aix-en-Provence</h2>
-    <div class="popup-images"><img src="assets/photos/creps aix en provence.jpg" alt="Aix" /></div>
-    <div class="popup-text">
-      <p>Un cadre provençal pour progresser avec des infrastructures de haut niveau.</p>
-      <h3>Journée type :</h3><ul>
-        <li>2 séances tennis</li>
-        <li>Renforcement musculaire</li>
-        <li>Analyse vidéo</li>
-      </ul>
-    </div>
-  </div>
-</div>
-<div id="popup-cabourg" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Tournée de tournois - Cabourg</h2>
-    <div class="popup-images"><img src="assets/photos/cabourg-tennis-club-sporting.webp" alt="Cabourg" /></div>
-    <div class="popup-text">
-      <p>Stage compétition avec participation à des tournois FFT tout au long de la semaine.</p>
-      <h3>Journée type :</h3><ul>
-        <li>Matchs FFT chaque jour</li>
-        <li>Coaching individualisé</li>
-        <li>Analyse tactique</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<script>
-function openPopup(id) {
-  document.getElementById(id).style.display = 'block';
-}
-function closePopup(e) {
-  if (e.target.classList.contains('popup') || e.target.classList.contains('close')) {
-    e.target.closest('.popup').style.display = 'none';
-  }
-}
-</script>
-
-
-
-
-<div id="popup-poitiers" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage avec sortie Futuroscope - Poitiers</h2>
-    <div class="popup-images"><img src="assets/photos/creps_poitiers_1.jpg" alt="Poitiers" /></div>
-    <div class="popup-text">
-      <p>Entraînement intensif dans une structure moderne avec en bonus une sortie exceptionnelle au parc du Futuroscope.</p>
-      <h3>Journée type :</h3>
-      <ul>
-        <li>2 séances tennis</li>
-        <li>Préparation mentale</li>
-        <li>Sortie d'une journée au Futuroscope</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-toulouse" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage + Cité de l’Espace - Toulouse</h2>
-    <div class="popup-images"><img src="assets/photos/creps toulouse.jpg" alt="Toulouse" /></div>
-    <div class="popup-text">
-      <p>Un stage enrichi par une sortie à la Cité de l’Espace pour mêler sport et culture scientifique dans un cadre motivant.</p>
-      <h3>Journée type :</h3>
-      <ul>
-        <li>2 entraînements tennis par jour</li>
-        <li>Renforcement musculaire + analyse vidéo</li>
-        <li>Sortie scientifique à la Cité de l’Espace</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-aix" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage intensif - Aix-en-Provence</h2>
-    <div class="popup-images"><img src="assets/photos/creps aix en provence.jpg" alt="Aix" /></div>
-    <div class="popup-text">
-      <p>Cadre ensoleillé au cœur de la Provence pour un stage haut niveau alliant tennis, prépa physique et récupération.</p>
-      <h3>Journée type :</h3>
-      <ul>
-        <li>2 séances tennis intensives</li>
-        <li>Préparation physique encadrée</li>
-        <li>Analyse vidéo + détente</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-cabourg" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Tournée de Tournois - Cabourg</h2>
-    <div class="popup-images"><img src="assets/photos/cabourg-tennis-club-sporting.webp" alt="Cabourg" /></div>
-    <div class="popup-text">
-      <p>Stage de compétition en bord de mer avec participation à des tournois FFT officiels et coaching personnalisé quotidien.</p>
-      <h3>Journée type :</h3>
-      <ul>
-        <li>1 match FFT par jour</li>
-        <li>Coaching tactique après chaque rencontre</li>
-        <li>Analyse vidéo + récupération</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-
-<!-- POPUPS PREMIUM FINAUX -->
-<div id="popup-hostens" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage Multisport - Hostens</h2>
-    <div class="popup-images"><img src="assets/photos/hostens_kurs.jpg" alt="Hostens" /></div>
-    <div class="popup-text">
-      <p>Un stage multisport dans un cadre naturel exceptionnel mêlant tennis, paddle, VTT et baignade en lac.</p>
-      <h3>Journée type :</h3><ul>
-        <li>1 séance tennis + activité extérieure</li>
-        <li>Déjeuner au bord du lac</li>
-        <li>Soirée animée (grillades, jeux)</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-poitiers" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage avec sortie Futuroscope - Poitiers</h2>
-    <div class="popup-images"><img src="assets/photos/1200x680_creps_2_poitiers.jpg" alt="Poitiers" /></div>
-    <div class="popup-text">
-      <p>Entraînement intensif dans une structure moderne avec en bonus une sortie exceptionnelle au parc du Futuroscope.</p>
-      <h3>Journée type :</h3><ul>
-        <li>2 séances tennis</li>
-        <li>Préparation mentale</li>
-        <li>Sortie d'une journée au Futuroscope</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-toulouse" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage + Cité de l’Espace - Toulouse</h2>
-    <div class="popup-images"><img src="assets/photos/creps toulouse.jpg" alt="Toulouse" /></div>
-    <div class="popup-text">
-      <p>Un stage enrichi par une sortie à la Cité de l’Espace pour mêler sport et culture scientifique dans un cadre motivant.</p>
-      <h3>Journée type :</h3><ul>
-        <li>2 entraînements tennis par jour</li>
-        <li>Renforcement musculaire + analyse vidéo</li>
-        <li>Sortie scientifique à la Cité de l’Espace</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-aix" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Stage intensif - Aix-en-Provence</h2>
-    <div class="popup-images"><img src="assets/photos/creps aix en provence.jpg" alt="Aix" /></div>
-    <div class="popup-text">
-      <p>Cadre ensoleillé au cœur de la Provence pour un stage haut niveau alliant tennis, prépa physique et récupération.</p>
-      <h3>Journée type :</h3><ul>
-        <li>2 séances tennis intensives</li>
-        <li>Préparation physique encadrée</li>
-        <li>Analyse vidéo + détente</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div id="popup-cabourg" class="popup" onclick="closePopup(event)">
-  <div class="popup-content">
-    <span class="close" onclick="closePopup(event)">&times;</span>
-    <h2>Tournée de Tournois - Cabourg</h2>
-    <div class="popup-images"><img src="assets/photos/cabourg-tennis-club-sporting.webp" alt="Cabourg" /></div>
-    <div class="popup-text">
-      <p>Stage compétition en bord de mer avec participation à des tournois FFT officiels et coaching personnalisé quotidien.</p>
-      <h3>Journée type :</h3><ul>
-        <li>1 match FFT par jour</li>
-        <li>Coaching tactique après chaque rencontre</li>
-        <li>Analyse vidéo + récupération</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
+    mainNav?.querySelectorAll('a, button').forEach(link => {
+      link.addEventListener('click', () => {
+        if (mainNav.classList.contains('is-open')) {
+          mainNav.classList.remove('is-open');
+          document.body.classList.remove('no-scroll');
+          navToggle?.setAttribute('aria-expanded', 'false');
+        }
+      });
+    });
+  </script>
 </body>
 </html>
-<style>
-.popup-hebergement {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0,0,0,0.6);
-  z-index: 9999;
-  justify-content: center;
-  align-items: center;
-}
-.popup-content {
-  background: #fff;
-  padding: 30px;
-  border-radius: 15px;
-  max-width: 600px;
-  width: 90%;
-  position: relative;
-}
-.popup-close {
-  position: absolute;
-  top: 10px;
-  right: 20px;
-  font-size: 24px;
-  cursor: pointer;
-}
-</style>
-<!-- POPUPS INDIVIDUELS PAR LIEU -->
-<!-- POPUP HOSTENS -->
-<div class="popup-overlay" id="popup-hostens" style="display:none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.75); z-index: 1000; justify-content: center; align-items: center;">
-<div class="popup-content" style="background: white; max-width: 900px; width: 90%; border-radius: 15px; overflow: hidden; position: relative; animation: fadeIn 0.4s ease;">
-<span onclick="closePopup('popup-hostens')" style="position: absolute; top: 15px; right: 20px; font-size: 24px; cursor: pointer;">×</span>
-<div style="display: flex; flex-direction: column;">
-<img alt="Hostens" src="assets/photos/1.png" style="width: 100%; height: 300px; object-fit: cover;"/>
-<div style="padding: 30px;">
-<h2 style="margin-top: 0;">Stage à Hostens</h2>
-<p><strong>Un site naturel en pleine forêt pour une immersion sportive et reposante près de Bordeaux.</strong></p>
-<p><em>Plus que 8 places disponibles</em></p>
-<p style="font-size: 1.2em; font-weight: bold;">1600 € <span style="font-size: 0.8em; font-weight: normal;">*Prix sans hébergement</span></p>
-<h3>Description</h3>
-<p>Le site d’Hostens, situé dans une réserve naturelle, offre un cadre exceptionnel pour une pratique intensive du tennis. Les infrastructures sportives sont à proximité immédiate du centre d’hébergement, garantissant confort, sécurité et efficacité dans les déplacements.</p>
-<h3>Une journée type :</h3>
-<ul>
-<li>7h30 : Réveil &amp; petit-déjeuner</li>
-<li>9h00 - 12h00 : Entraînement tennis + préparation physique</li>
-<li>12h30 : Déjeuner &amp; temps calme</li>
-<li>14h30 - 17h00 : Tennis, matchs, coaching mental</li>
-<li>18h00 : Activité détente (lac, forêt, vélo)</li>
-<li>20h00 : Dîner &amp; briefing du lendemain</li>
-</ul>
-<h3>Prestations incluses :</h3>
-<ul>
-<li>Encadrement par coachs diplômés</li>
-<li>Analyse vidéo &amp; coaching personnalisé</li>
-<li>Accès aux infrastructures sportives</li>
-<li>Maillot Tennis Impact offert</li>
-</ul>
-<button style="margin-top: 20px; padding: 12px 24px; background: #000; color: #fff; border: none; border-radius: 25px; font-size: 1em; cursor: pointer;">Ajouter ce stage</button>
-</div>
-</div>
-</div>
-</div>
-<script>
-function openPopup(id) {
-  document.getElementById(id).style.display = "flex";
-}
-function closePopup(id) {
-  document.getElementById(id).style.display = "none";
-}
-window.addEventListener('click', function(e) {
-  const popup = document.getElementById('popup-hostens');
-  if (e.target === popup) closePopup('popup-hostens');
-});
-</script>
-<!-- POPUP FORMULAIRE -->
-<div class="popup-overlay" id="popup-formulaire" style="display:none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.75); z-index: 10000; justify-content: center; align-items: center;">
-<div class="popup-content" style="background: white; max-width: 600px; width: 90%; border-radius: 15px; overflow: hidden; position: relative; animation: fadeIn 0.4s ease; padding: 30px; font-family: Poppins, sans-serif;">
-<span onclick="closePopup('popup-formulaire')" style="position: absolute; top: 15px; right: 20px; font-size: 24px; cursor: pointer;">×</span>
-<h2 style="margin-top: 0; text-align:center;">Réserver mon stage</h2>
-<form id="form-reservation">
-<label>Prénom</label><br/>
-<input name="prenom" required="" style="width:100%; padding:10px; margin-bottom:10px;" type="text"/><br/>
-<label>Nom</label><br/>
-<input name="nom" required="" style="width:100%; padding:10px; margin-bottom:10px;" type="text"/><br/>
-<label>Âge</label><br/>
-<input name="age" required="" style="width:100%; padding:10px; margin-bottom:10px;" type="number"/><br/>
-<label>Email</label><br/>
-<input name="email" required="" style="width:100%; padding:10px; margin-bottom:10px;" type="email"/><br/>
-<label>Téléphone</label><br/>
-<input name="tel" required="" style="width:100%; padding:10px; margin-bottom:10px;" type="tel"/><br/>
-<label>Niveau</label><br/>
-<select name="niveau" required="" style="width:100%; padding:10px; margin-bottom:10px;">
-<option value="">Sélectionner</option>
-<option>Débutant</option>
-<option>Intermédiaire</option>
-<option>Avancé</option>
-<option>Classé FFT</option>
-</select><br/>
-<label>Nos Hébergements</label><br/>
-<select name="hebergement" required="" style="width:100%; padding:10px; margin-bottom:20px;">
-<option value="">Sélectionner</option>
-<option>Avec hébergement</option>
-<option>Sans hébergement</option>
-</select><br/>
-<button style="width:100%; padding:12px; background:#000; color:#fff; border:none; border-radius:25px; font-size:1em;" type="submit">Envoyer ma réservation</button>
-</form>
-</div>
-</div>
-<script>
-function validerReservation() {
-  document.getElementById('popup-formulaire').style.display = "flex";
-}
-</script>

--- a/style.css
+++ b/style.css
@@ -30,6 +30,7 @@ body {
   background: var(--color-white);
   line-height: 1.6;
   scroll-behavior: smooth;
+  overflow-x: hidden;
 }
 
 img {
@@ -149,14 +150,34 @@ ul {
 .navbar__links {
   display: flex;
   align-items: center;
+  margin-left: auto;
+}
+
+.navbar__menu {
+  display: flex;
+  align-items: center;
   gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.navbar__menu li {
+  display: flex;
 }
 
 .nav-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding-bottom: 0.2rem;
   color: var(--color-white);
   font-weight: 500;
-  position: relative;
-  padding-bottom: 0.2rem;
+  font-family: inherit;
+  background: none;
+  border: none;
+  cursor: pointer;
 }
 
 .nav-link::after {
@@ -175,10 +196,22 @@ ul {
   width: 100%;
 }
 
-.navbar__cta {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
+.nav-link--cta {
+  padding: 0.55rem 1.3rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  transition: background var(--transition-base), transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.nav-link--cta::after {
+  display: none;
+}
+
+.nav-link--cta:hover,
+.nav-link--cta:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px rgba(5, 10, 15, 0.28);
 }
 
 .navbar__toggle {
@@ -252,6 +285,60 @@ ul {
   gap: 1rem;
   flex-wrap: wrap;
   margin-bottom: 2.5rem;
+}
+
+.hero__link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  color: var(--color-navy-700);
+  transition: color var(--transition-base);
+}
+
+.hero__link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -0.3rem;
+  width: 100%;
+  height: 1px;
+  background: currentColor;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--transition-base);
+}
+
+.hero__link:hover::after,
+.hero__link:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.hero__link-icon {
+  transition: transform var(--transition-base);
+  font-size: 1.1em;
+}
+
+.hero__link:hover .hero__link-icon,
+.hero__link:focus-visible .hero__link-icon {
+  transform: translateX(4px);
+}
+
+.hero__link:hover,
+.hero__link:focus-visible {
+  color: var(--color-navy);
+}
+
+.hero__link--light {
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.hero__link--light:hover,
+.hero__link--light:focus-visible {
+  color: var(--color-gold);
 }
 
 .hero__badges {
@@ -731,28 +818,46 @@ ul {
 
   .navbar__links {
     position: fixed;
-    inset: 0 0 auto;
     top: 72px;
-    flex-direction: column;
-    align-items: flex-start;
+    left: 0;
+    right: 0;
+    bottom: 0;
     background: rgba(5, 10, 15, 0.94);
-    padding: 2rem;
+    padding: 2.5rem 2rem 3rem;
     transform: translateY(-120%);
     transition: transform 0.35s ease;
-    gap: 1.4rem;
+    backdrop-filter: blur(16px);
+    margin-left: 0;
   }
 
   .navbar__links.is-open {
     transform: translateY(0);
   }
 
-  .navbar__cta {
+  .navbar__menu {
     flex-direction: column;
-    align-self: stretch;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .navbar__menu li {
+    width: 100%;
   }
 
   .btn--ghost {
     border-color: rgba(255, 255, 255, 0.3);
+  }
+
+  .nav-link {
+    justify-content: flex-start;
+    font-size: 1.1rem;
+  }
+
+  .nav-link--cta {
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    padding: 0.9rem 1.2rem;
+    justify-content: center;
+    width: 100%;
   }
 
   .section__grid {


### PR DESCRIPTION
## Summary
- standardize the premium navigation with list-based menus, contact access, and smoother mobile toggling across all booking pages
- refresh hero sections with lighter CTA links, arrow accents, and distinct high-end photography on stages, leçons, and coach areas
- keep reservation flows focused on Paris/Colmar choices while ensuring in-page CTAs and scripts close the mobile menu when navigating

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4d8cdc0088325a2dae9d59dbf1caa