### PR TITLE
Update hero headline to emphasize academy pillars

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,20 +48,14 @@
           Programmes signature, staff d'élite et service concierge : Tennis Impact sublime votre jeu avec un accompagnement
           sur-mesure et une attention à chaque détail.
         </p>
-        <ul class="hero__pillars" aria-label="Les trois piliers Tennis Impact">
-          <li class="hero__pillar">
-            <span class="hero__pillar-title">Performance</span>
-            <p class="hero__pillar-text">Méthodologie data-driven, ateliers tactiques et préparation physique intégrée.</p>
-          </li>
-          <li class="hero__pillar">
-            <span class="hero__pillar-title">Plaisir</span>
-            <p class="hero__pillar-text">Séances immersives, rythme adapté et ambiance inspirante pour garder le sourire.</p>
-          </li>
-          <li class="hero__pillar">
-            <span class="hero__pillar-title">Signature</span>
-            <p class="hero__pillar-text">Service premium, attention aux détails et suivi continu sur et en dehors du court.</p>
-          </li>
-        </ul>
+        <div class="hero__pillars-text">
+          <p>
+            Trois piliers guident nos stages élites :
+            <span class="hero__pillars-highlight">performance totale</span> pour pousser chaque échange,
+            <span class="hero__pillars-highlight">coaching sur-mesure</span> afin de révéler votre style de jeu,
+            et une <span class="hero__pillars-highlight">expérience premium</span> qui prend soin de chaque détail sur et hors du court.
+          </p>
+        </div>
         <div class="hero__actions">
           <a class="btn btn--gold" href="reserver.html">Réserver un stage</a>
           <a class="btn btn--ghost" href="reservation_lecon.html">Planifier une leçon</a>

--- a/style.css
+++ b/style.css
@@ -262,62 +262,23 @@ ul {
   margin-bottom: 2rem;
 }
 
-.hero__pillars {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.25rem;
-  list-style: none;
-  padding: 0;
-  margin: 0 0 2.5rem;
+.hero__pillars-text {
+  margin-bottom: 2.5rem;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.86);
+  max-width: 48rem;
 }
 
-.hero__pillar {
-  position: relative;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 20px;
-  padding: 1.4rem 1.6rem 1.6rem;
-  backdrop-filter: blur(10px);
-  transition: transform 0.4s ease, border-color 0.4s ease, background 0.4s ease;
+.hero__pillars-text p {
+  margin: 0;
 }
 
-.hero__pillar::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 1px;
-  background: linear-gradient(140deg, rgba(249, 214, 92, 0.7), rgba(255, 255, 255, 0));
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  opacity: 0;
-  transition: opacity 0.4s ease;
-}
-
-.hero__pillar:hover {
-  transform: translateY(-6px);
-  border-color: rgba(249, 214, 92, 0.55);
-  background: rgba(255, 255, 255, 0.12);
-}
-
-.hero__pillar:hover::before {
-  opacity: 1;
-}
-
-.hero__pillar-title {
-  display: block;
-  font-family: var(--font-heading);
-  font-size: 1.25rem;
-  margin-bottom: 0.75rem;
+.hero__pillars-highlight {
+  font-weight: 600;
   color: var(--color-gold);
+  text-transform: uppercase;
   letter-spacing: 0.5px;
-}
-
-.hero__pillar-text {
-  font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.78);
-  line-height: 1.5;
 }
 
 .hero__actions {
@@ -842,14 +803,8 @@ ul {
     justify-content: center;
   }
 
-  .hero__pillars {
-    margin-left: auto;
-    margin-right: auto;
-    text-align: left;
-  }
-
-  .hero__pillar {
-    text-align: left;
+  .hero__pillars-text {
+    text-align: center;
   }
 
   .hero__badges {


### PR DESCRIPTION
## Summary
- replace the hero pillar cards with a single accroche that highlights the three pillars of the academy
- add styling for the new highlighted text and ensure it centers correctly on small screens

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e60e1199b88325b770694fe99ea45b