### PR TITLE
Lighten hero messaging and pillar display

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,42 +43,18 @@
       </video>
       <div class="container hero__content" data-aos="fade-up">
         <p class="hero__subtitle">Académie de tennis haute performance</p>
-        <h1>Performance, plaisir et excellence à chaque échange</h1>
+        <h1>Le tennis d'élite avec l'esprit club</h1>
         <p class="hero__description">
-          Programmes signature, staff d'élite et service concierge : Tennis Impact sublime votre jeu avec un accompagnement
-          sur-mesure et une attention à chaque détail.
+          Des stages intimistes, un coaching individualisé et un cadre premium pour progresser sereinement toute l'année.
         </p>
-        <ul class="hero__pillars" aria-label="Les trois piliers Tennis Impact">
-          <li class="hero__pillar">
-            <span class="hero__pillar-title">Performance</span>
-            <p class="hero__pillar-text">Méthodologie data-driven, ateliers tactiques et préparation physique intégrée.</p>
-          </li>
-          <li class="hero__pillar">
-            <span class="hero__pillar-title">Plaisir</span>
-            <p class="hero__pillar-text">Séances immersives, rythme adapté et ambiance inspirante pour garder le sourire.</p>
-          </li>
-          <li class="hero__pillar">
-            <span class="hero__pillar-title">Signature</span>
-            <p class="hero__pillar-text">Service premium, attention aux détails et suivi continu sur et en dehors du court.</p>
-          </li>
-        </ul>
+        <div class="hero__pillars" aria-label="Les piliers de Tennis Impact">
+          <span class="hero__pill">Coaching sur-mesure</span>
+          <span class="hero__pill">Préparation complète</span>
+          <span class="hero__pill">Expérience premium</span>
+        </div>
         <div class="hero__actions">
           <a class="btn btn--gold" href="reserver.html">Réserver un stage</a>
           <a class="btn btn--ghost" href="reservation_lecon.html">Planifier une leçon</a>
-        </div>
-        <div class="hero__badges" data-aos="fade-up" data-aos-delay="200">
-          <div class="badge">
-            <span class="badge__title">100+</span>
-            <span class="badge__text">joueurs accompagnés</span>
-          </div>
-          <div class="badge">
-            <span class="badge__title">15 ans</span>
-            <span class="badge__text">d'expérience coaching</span>
-          </div>
-          <div class="badge">
-            <span class="badge__title">100% perso</span>
-            <span class="badge__text">programmes individualisés</span>
-          </div>
         </div>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -230,7 +230,7 @@ ul {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(7, 17, 29, 0.78), rgba(17, 41, 68, 0.58));
+  background: linear-gradient(118deg, rgba(7, 17, 29, 0.68), rgba(17, 41, 68, 0.32));
   z-index: -1;
 }
 
@@ -260,64 +260,31 @@ ul {
   font-size: 1.05rem;
   color: rgba(255, 255, 255, 0.82);
   margin-bottom: 2rem;
+  max-width: 36rem;
 }
+
+
 
 .hero__pillars {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.25rem;
-  list-style: none;
-  padding: 0;
-  margin: 0 0 2.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
 }
 
-.hero__pillar {
-  position: relative;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 20px;
-  padding: 1.4rem 1.6rem 1.6rem;
-  backdrop-filter: blur(10px);
-  transition: transform 0.4s ease, border-color 0.4s ease, background 0.4s ease;
-}
-
-.hero__pillar::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 1px;
-  background: linear-gradient(140deg, rgba(249, 214, 92, 0.7), rgba(255, 255, 255, 0));
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  opacity: 0;
-  transition: opacity 0.4s ease;
-}
-
-.hero__pillar:hover {
-  transform: translateY(-6px);
-  border-color: rgba(249, 214, 92, 0.55);
-  background: rgba(255, 255, 255, 0.12);
-}
-
-.hero__pillar:hover::before {
-  opacity: 1;
-}
-
-.hero__pillar-title {
-  display: block;
-  font-family: var(--font-heading);
-  font-size: 1.25rem;
-  margin-bottom: 0.75rem;
-  color: var(--color-gold);
-  letter-spacing: 0.5px;
-}
-
-.hero__pillar-text {
-  font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.78);
-  line-height: 1.5;
+.hero__pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(249, 214, 92, 0.38);
+  background: rgba(9, 20, 33, 0.24);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 10px 24px rgba(5, 10, 15, 0.18);
 }
 
 .hero__actions {
@@ -328,33 +295,6 @@ ul {
   margin-bottom: 2.5rem;
 }
 
-.hero__badges {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.badge {
-  backdrop-filter: blur(8px);
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 20px;
-  padding: 1rem 1.4rem;
-  min-width: 150px;
-  text-align: center;
-}
-
-.badge__title {
-  display: block;
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: var(--color-gold);
-}
-
-.badge__text {
-  font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.76);
-}
 
 .section {
   padding: clamp(4rem, 8vw, 6rem) 0;
@@ -843,17 +783,13 @@ ul {
   }
 
   .hero__pillars {
-    margin-left: auto;
-    margin-right: auto;
-    text-align: left;
-  }
-
-  .hero__pillar {
-    text-align: left;
-  }
-
-  .hero__badges {
     justify-content: center;
+    gap: 0.6rem;
+  }
+
+  .hero__pill {
+    width: 100%;
+    max-width: 320px;
   }
 
   .section__content p {
@@ -870,31 +806,31 @@ ul {
   }
 }
 
-@media (max-width: 640px) {
-  .navbar__brand img {
-    width: 150px;
-  }
+  @media (max-width: 640px) {
+    .navbar__brand img {
+      width: 150px;
+    }
 
-  .hero {
-    padding: 5rem 0 4rem;
-  }
+    .hero {
+      padding: 5rem 0 4rem;
+    }
 
-  .hero__description {
-    font-size: 0.95rem;
-  }
+    .hero__description {
+      font-size: 0.95rem;
+    }
 
-  .badge {
-    min-width: 120px;
-    padding: 0.9rem 1.1rem;
-  }
+    .hero__pill {
+      font-size: 0.78rem;
+      padding: 0.5rem 1rem;
+    }
 
-  .card__body {
-    padding: 1.6rem;
-  }
+    .card__body {
+      padding: 1.6rem;
+    }
 
-  .card__image {
-    height: 200px;
-  }
+    .card__image {
+      height: 200px;
+    }
 
   .footer__grid {
     gap: 2rem;


### PR DESCRIPTION
## Summary
- replace the hero heading and description with a shorter message focused on serenity and intimacy
- swap the previous paragraph list for three lightweight pillar badges and soften the video overlay styling for an airier feel

## Testing
- not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68e60e1199b88325b770694fe99ea45b