### PR TITLE
Refocus hero on Tennis Impact pillars

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,332 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>FAQ Tennis Impact – Stages &amp; leçons hautes performances</title>
+  <meta
+    name="description"
+    content="Questions fréquentes sur les stages tennis jeunes et les leçons individuelles Tennis Impact à Bordeaux."
+  />
+  <link rel="canonical" href="https://tennisimpact.fr/faq" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="FAQ Tennis Impact" />
+  <meta
+    property="og:description"
+    content="Toutes les réponses sur nos stages intensifs, coaching FFT et services premium à Bordeaux."
+  />
+  <meta property="og:url" content="https://tennisimpact.fr/faq" />
+  <meta property="og:image" content="https://tennisimpact.fr/assets/images/hero-illustration.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="FAQ Tennis Impact" />
+  <meta
+    name="twitter:description"
+    content="Découvrez comment rejoindre les stages Tennis Impact et préparer vos tournois."
+  />
+  <meta name="twitter:image" content="https://tennisimpact.fr/assets/images/hero-illustration.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://unpkg.com/aos@2.3.1/dist/aos.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="navbar" id="top">
+    <div class="navbar__container">
+      <a class="navbar__brand" href="index.html" aria-label="Accueil Tennis Impact">
+        <img src="assets/images/logo.svg" alt="Tennis Impact" />
+      </a>
+      <button class="navbar__toggle" id="navToggle" aria-expanded="false" aria-controls="mainNav" aria-label="Ouvrir le menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <nav class="navbar__links" id="mainNav">
+        <a href="notre-academie.html" class="nav-link">Notre académie</a>
+        <a href="stages_jeunes.html" class="nav-link">Stages</a>
+        <a href="lecon_individuelle.html" class="nav-link">Leçons individuelles</a>
+        <a href="faq.html" class="nav-link" aria-current="page">FAQ</a>
+        <a href="galerie.html" class="nav-link">Galerie</a>
+        <div class="navbar__cta">
+          <a class="btn btn--gold" href="reserver.html" aria-label="Réserver un stage Tennis Impact">Réserver un stage</a>
+          <button class="btn btn--outline" data-open-contact aria-label="Ouvrir le formulaire de contact Tennis Impact">Contact</button>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section" id="faq-intro">
+      <div class="container section__intro" data-aos="fade-up">
+        <span class="eyebrow">FAQ</span>
+        <h1>Tout savoir sur nos stages et leçons Tennis Impact</h1>
+        <p>Préparez votre venue à Bordeaux : modalités de stages, coaching individuel, hébergement, logistique et paiements.</p>
+      </div>
+    </section>
+
+    <section class="section section--dark" id="faq">
+      <div class="container">
+        <div class="section__intro" data-aos="fade-up">
+          <span class="eyebrow eyebrow--light">Questions récurrentes</span>
+          <h2>Vos questions, nos réponses</h2>
+          <p>Nous mettons à jour cette page au fil des retours de joueurs et de parents pour vous garantir une organisation fluide.</p>
+        </div>
+        <div class="faq" data-aos="fade-up" data-aos-delay="120">
+          <button class="faq__question" aria-expanded="false">
+            Quels sont les niveaux acceptés ?
+          </button>
+          <div class="faq__answer">
+            Tous les niveaux sont accueillis : initiation, perfectionnement et compétition. Les groupes sont constitués par âge et niveau pour garantir une progression optimale.
+          </div>
+
+          <button class="faq__question" aria-expanded="false">
+            Quel est le ratio coachs / joueurs ?
+          </button>
+          <div class="faq__answer">
+            Nous maintenons un ratio maximum de 1 coach pour 4 joueurs sur les ateliers techniques, et 1 coach pour 2 joueurs en séance vidéo-analyse.
+          </div>
+
+          <button class="faq__question" aria-expanded="false">
+            Proposez-vous un hébergement ?
+          </button>
+          <div class="faq__answer">
+            L'hébergement premium est disponible en option à proximité du club. Notre équipe s'occupe des transferts, repas et de l'assistance parents.
+          </div>
+
+          <button class="faq__question" aria-expanded="false">
+            Comment fonctionne le paiement des stages ?
+          </button>
+          <div class="faq__answer">
+            Un acompte de 30% est demandé à la réservation via notre panier sécurisé. Le solde est réglé 15 jours avant le début du stage ou sur place.
+          </div>
+
+          <button class="faq__question" aria-expanded="false">
+            Les adultes peuvent-ils participer ?
+          </button>
+          <div class="faq__answer">
+            Oui, des créneaux spécifiques et des tournées FFT sont ouverts aux adultes souhaitant performer en compétition ou reprendre avec un suivi structuré.
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="contact">
+      <div class="container section__intro" data-aos="fade-up">
+        <span class="eyebrow">Besoin d'un conseil ?</span>
+        <h2>Parlons de votre prochain objectif</h2>
+        <p>Un conseiller Tennis Impact vous répond en moins de 24h pour définir le format idéal : stage intensif, tournée ou coaching individuel.</p>
+        <div class="section__footer">
+          <a class="btn btn--gold" href="reserver.html">Réserver un stage</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <div class="cart-feedback" id="cartFeedback" role="status" aria-live="polite" hidden></div>
+
+  <footer class="footer">
+    <div class="container footer__grid">
+      <div>
+        <img src="assets/images/logo.svg" alt="Tennis Impact" class="footer__logo" />
+        <p>Académie de tennis premium à Bordeaux. Stages jeunes, coaching individuel et préparation de compétitions.</p>
+      </div>
+      <div>
+        <h3>Nous contacter</h3>
+        <ul class="footer__list">
+          <li><a href="tel:+33500000000">+33 (0)5 00 00 00 00</a></li>
+          <li><a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a></li>
+          <li>14 avenue du Court Central – 33000 Bordeaux</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Newsletter</h3>
+        <form class="newsletter" id="newsletterForm">
+          <label class="sr-only" for="newsletterEmail">Votre email</label>
+          <input id="newsletterEmail" type="email" name="email" placeholder="Votre email" required />
+          <button type="submit" class="btn btn--gold">S'inscrire</button>
+        </form>
+        <p class="footer__note">En vous inscrivant vous acceptez notre <a href="politique-confidentialite.html">politique de confidentialité</a>.</p>
+      </div>
+    </div>
+    <div class="footer__bottom">
+      <div class="container footer__bottom-inner">
+        <p>© <span id="currentYear"></span> Tennis Impact. Tous droits réservés.</p>
+        <div class="footer__links">
+          <a href="#">Mentions légales</a>
+          <a href="#">Conditions générales</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <div class="contact-modal" id="contactModal" role="dialog" aria-modal="true" aria-labelledby="contactTitle" hidden>
+    <div class="contact-modal__overlay" data-close-contact></div>
+    <div class="contact-modal__content">
+      <button class="contact-modal__close" type="button" data-close-contact aria-label="Fermer le formulaire">
+        ×
+      </button>
+      <h2 id="contactTitle">Contactez-nous</h2>
+      <p>Parlez-nous de votre projet tennistique, nous vous répondons sous 24h.</p>
+      <form id="contactForm" class="contact-form">
+        <label for="contactName">Nom complet</label>
+        <input id="contactName" name="name" type="text" placeholder="Votre nom" required />
+
+        <label for="contactEmail">Email</label>
+        <input id="contactEmail" name="email" type="email" placeholder="Votre email" required />
+
+        <label for="contactMessage">Message</label>
+        <textarea id="contactMessage" name="message" rows="4" placeholder="Parlez-nous de vos objectifs" required></textarea>
+
+        <label class="sr-only" for="contactStageType">Type de demande</label>
+        <select id="contactStageType" name="stage" required>
+          <option value="" disabled selected>Type de stage</option>
+          <option value="intensif">Stage intensif</option>
+          <option value="tournoi">Tournée tournois</option>
+          <option value="lecon">Leçon individuelle</option>
+        </select>
+
+        <div class="sr-only" aria-hidden="true">
+          <label for="contactCompany">Ne pas remplir ce champ</label>
+          <input id="contactCompany" type="text" name="company" tabindex="-1" autocomplete="off" />
+        </div>
+
+        <button type="submit" class="btn btn--gold btn--full">Envoyer</button>
+      </form>
+      <p class="contact-modal__success" id="contactSuccess" role="status" aria-live="polite" tabindex="-1" hidden>
+        Merci, votre demande a bien été envoyée.
+      </p>
+      <p class="contact-modal__rgpd">Vos données ne sont utilisées que pour répondre à votre demande. Consultez notre <a href="politique-confidentialite.html">politique de confidentialité</a>.</p>
+    </div>
+  </div>
+
+  <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+  <script>
+    AOS.init({
+      once: true,
+      offset: 120,
+      duration: 600,
+      easing: 'ease-out-quart'
+    });
+
+    const navToggle = document.getElementById('navToggle');
+    const nav = document.getElementById('mainNav');
+    const body = document.body;
+
+    function closeNav() {
+      nav.classList.remove('is-open');
+      navToggle.setAttribute('aria-expanded', 'false');
+      body.classList.remove('no-scroll');
+    }
+
+    navToggle.addEventListener('click', () => {
+      const isOpen = nav.classList.toggle('is-open');
+      navToggle.setAttribute('aria-expanded', String(isOpen));
+      body.classList.toggle('no-scroll', isOpen);
+    });
+
+    nav.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        if (nav.classList.contains('is-open')) {
+          closeNav();
+        }
+      });
+    });
+
+    const contactModal = document.getElementById('contactModal');
+    const contactForm = document.getElementById('contactForm');
+    const contactSuccess = document.getElementById('contactSuccess');
+    let contactSuccessTimeout;
+
+    function closeContact() {
+      contactModal.classList.remove('is-visible');
+      body.classList.remove('no-scroll');
+      setTimeout(() => {
+        contactModal.hidden = true;
+        contactSuccess.hidden = true;
+        contactForm.reset();
+        if (contactSuccessTimeout) {
+          clearTimeout(contactSuccessTimeout);
+          contactSuccessTimeout = null;
+        }
+      }, 300);
+    }
+
+    function openContact() {
+      closeNav();
+      contactModal.hidden = false;
+      requestAnimationFrame(() => {
+        contactModal.classList.add('is-visible');
+        body.classList.add('no-scroll');
+      });
+    }
+
+    document.querySelectorAll('[data-open-contact]').forEach(btn => btn.addEventListener('click', openContact));
+    contactModal.querySelectorAll('[data-close-contact]').forEach(btn => btn.addEventListener('click', closeContact));
+
+    contactForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const honeypot = contactForm.querySelector('[name="company"]');
+      if (honeypot && honeypot.value.trim() !== '') {
+        return;
+      }
+      contactSuccess.hidden = false;
+      contactSuccess.focus();
+      if (contactSuccessTimeout) {
+        clearTimeout(contactSuccessTimeout);
+      }
+      contactSuccessTimeout = setTimeout(() => {
+        closeContact();
+      }, 4000);
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && contactModal.classList.contains('is-visible')) {
+        closeContact();
+      }
+    });
+
+    const faqQuestions = document.querySelectorAll('.faq__question');
+    faqQuestions.forEach((button, index) => {
+      button.addEventListener('click', () => {
+        const expanded = button.getAttribute('aria-expanded') === 'true';
+        button.setAttribute('aria-expanded', String(!expanded));
+        button.classList.toggle('is-active');
+        const answer = button.nextElementSibling;
+        answer.style.maxHeight = expanded ? null : answer.scrollHeight + 'px';
+      });
+      if (index === 0) {
+        button.click();
+      }
+    });
+
+    const addToCartButtons = document.querySelectorAll('[data-add]');
+    const cartFeedback = document.getElementById('cartFeedback');
+    let cartFeedbackTimeout;
+
+    addToCartButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const label = button.getAttribute('data-name') || 'Stage';
+        cartFeedback.textContent = `${label} ajouté au panier ✔︎`;
+        cartFeedback.hidden = false;
+        cartFeedback.classList.add('is-visible');
+        if (cartFeedbackTimeout) {
+          clearTimeout(cartFeedbackTimeout);
+        }
+        cartFeedbackTimeout = setTimeout(() => {
+          cartFeedback.classList.remove('is-visible');
+          cartFeedback.hidden = true;
+        }, 3200);
+      });
+    });
+
+    const newsletterForm = document.getElementById('newsletterForm');
+    newsletterForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      alert('Merci ! Vous êtes inscrit à la newsletter Tennis Impact.');
+      newsletterForm.reset();
+    });
+
+    document.getElementById('currentYear').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/galerie.html
+++ b/galerie.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Galerie Tennis Impact – Moments clés des stages</title>
+  <meta
+    name="description"
+    content="Plongez dans les coulisses des stages Tennis Impact : entraînements, coaching FFT, ambiance premium à Bordeaux."
+  />
+  <link rel="canonical" href="https://tennisimpact.fr/galerie" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Galerie Tennis Impact" />
+  <meta
+    property="og:description"
+    content="Découvrez les images de nos stages intensifs, leçons individuelles et tournées FFT à Bordeaux."
+  />
+  <meta property="og:url" content="https://tennisimpact.fr/galerie" />
+  <meta property="og:image" content="https://tennisimpact.fr/assets/images/hero-illustration.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Galerie Tennis Impact" />
+  <meta
+    name="twitter:description"
+    content="Ambiance premium et intensité des stages Tennis Impact en images."
+  />
+  <meta name="twitter:image" content="https://tennisimpact.fr/assets/images/hero-illustration.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://unpkg.com/aos@2.3.1/dist/aos.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="navbar" id="top">
+    <div class="navbar__container">
+      <a class="navbar__brand" href="index.html" aria-label="Accueil Tennis Impact">
+        <img src="assets/images/logo.svg" alt="Tennis Impact" />
+      </a>
+      <button class="navbar__toggle" id="navToggle" aria-expanded="false" aria-controls="mainNav" aria-label="Ouvrir le menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <nav class="navbar__links" id="mainNav">
+        <a href="notre-academie.html" class="nav-link">Notre académie</a>
+        <a href="stages_jeunes.html" class="nav-link">Stages</a>
+        <a href="lecon_individuelle.html" class="nav-link">Leçons individuelles</a>
+        <a href="faq.html" class="nav-link">FAQ</a>
+        <a href="galerie.html" class="nav-link" aria-current="page">Galerie</a>
+        <div class="navbar__cta">
+          <a class="btn btn--gold" href="reserver.html" aria-label="Réserver un stage Tennis Impact">Réserver un stage</a>
+          <button class="btn btn--outline" data-open-contact aria-label="Ouvrir le formulaire de contact Tennis Impact">Contact</button>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section" id="galerie-intro">
+      <div class="container section__intro" data-aos="fade-up">
+        <span class="eyebrow">Galerie</span>
+        <h1>Les coulisses de Tennis Impact en images</h1>
+        <p>Training haute intensité, coaching mental, cohésion d'équipe : explorez l'expérience Tennis Impact sur nos courts à Bordeaux.</p>
+      </div>
+    </section>
+
+    <section class="section" id="galerie">
+      <div class="container">
+        <div class="gallery" data-aos="fade-up" data-aos-delay="100">
+          <img src="assets/images/gallery-1.svg" alt="Coup droit en extension lors d'un stage intensif" width="360" height="240" loading="lazy" decoding="async" />
+          <img src="assets/images/gallery-2.svg" alt="Séance de préparation physique collective" width="360" height="240" loading="lazy" decoding="async" />
+          <img src="assets/images/gallery-3.svg" alt="Match d'entraînement coaché" width="360" height="240" loading="lazy" decoding="async" />
+          <img src="assets/images/gallery-4.svg" alt="Coaching individuel au filet" width="360" height="240" loading="lazy" decoding="async" />
+          <img src="assets/images/gallery-5.svg" alt="Moment d'équipe pendant un stage Tennis Impact" width="360" height="240" loading="lazy" decoding="async" />
+          <img src="assets/images/gallery-6.svg" alt="Vue du centre Tennis Impact à Bordeaux" width="360" height="240" loading="lazy" decoding="async" />
+        </div>
+        <div class="section__footer" data-aos="fade-up" data-aos-delay="160">
+          <a class="btn btn--gold" href="reserver.html">Réserver un stage</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--highlight" id="galerie-video">
+      <div class="container section__intro" data-aos="fade-up">
+        <span class="eyebrow">Vidéo</span>
+        <h2>Découvrez une journée type en stage intensif</h2>
+        <p>Échauffement, ateliers spécifiques, vidéo-analyse et coaching mental : plongez au cœur de la méthode Impact 360°.</p>
+        <div class="section__footer">
+          <a class="btn btn--outline" href="https://www.youtube.com" target="_blank" rel="noopener">Regarder la vidéo</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <div class="cart-feedback" id="cartFeedback" role="status" aria-live="polite" hidden></div>
+
+  <footer class="footer">
+    <div class="container footer__grid">
+      <div>
+        <img src="assets/images/logo.svg" alt="Tennis Impact" class="footer__logo" />
+        <p>Académie de tennis premium à Bordeaux. Stages jeunes, coaching individuel et préparation de compétitions.</p>
+      </div>
+      <div>
+        <h3>Nous contacter</h3>
+        <ul class="footer__list">
+          <li><a href="tel:+33500000000">+33 (0)5 00 00 00 00</a></li>
+          <li><a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a></li>
+          <li>14 avenue du Court Central – 33000 Bordeaux</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Newsletter</h3>
+        <form class="newsletter" id="newsletterForm">
+          <label class="sr-only" for="newsletterEmail">Votre email</label>
+          <input id="newsletterEmail" type="email" name="email" placeholder="Votre email" required />
+          <button type="submit" class="btn btn--gold">S'inscrire</button>
+        </form>
+        <p class="footer__note">En vous inscrivant vous acceptez notre <a href="politique-confidentialite.html">politique de confidentialité</a>.</p>
+      </div>
+    </div>
+    <div class="footer__bottom">
+      <div class="container footer__bottom-inner">
+        <p>© <span id="currentYear"></span> Tennis Impact. Tous droits réservés.</p>
+        <div class="footer__links">
+          <a href="#">Mentions légales</a>
+          <a href="#">Conditions générales</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <div class="contact-modal" id="contactModal" role="dialog" aria-modal="true" aria-labelledby="contactTitle" hidden>
+    <div class="contact-modal__overlay" data-close-contact></div>
+    <div class="contact-modal__content">
+      <button class="contact-modal__close" type="button" data-close-contact aria-label="Fermer le formulaire">
+        ×
+      </button>
+      <h2 id="contactTitle">Contactez-nous</h2>
+      <p>Parlez-nous de votre projet tennistique, nous vous répondons sous 24h.</p>
+      <form id="contactForm" class="contact-form">
+        <label for="contactName">Nom complet</label>
+        <input id="contactName" name="name" type="text" placeholder="Votre nom" required />
+
+        <label for="contactEmail">Email</label>
+        <input id="contactEmail" name="email" type="email" placeholder="Votre email" required />
+
+        <label for="contactMessage">Message</label>
+        <textarea id="contactMessage" name="message" rows="4" placeholder="Parlez-nous de vos objectifs" required></textarea>
+
+        <label class="sr-only" for="contactStageType">Type de demande</label>
+        <select id="contactStageType" name="stage" required>
+          <option value="" disabled selected>Type de stage</option>
+          <option value="intensif">Stage intensif</option>
+          <option value="tournoi">Tournée tournois</option>
+          <option value="lecon">Leçon individuelle</option>
+        </select>
+
+        <div class="sr-only" aria-hidden="true">
+          <label for="contactCompany">Ne pas remplir ce champ</label>
+          <input id="contactCompany" type="text" name="company" tabindex="-1" autocomplete="off" />
+        </div>
+
+        <button type="submit" class="btn btn--gold btn--full">Envoyer</button>
+      </form>
+      <p class="contact-modal__success" id="contactSuccess" role="status" aria-live="polite" tabindex="-1" hidden>
+        Merci, votre demande a bien été envoyée.
+      </p>
+      <p class="contact-modal__rgpd">Vos données ne sont utilisées que pour répondre à votre demande. Consultez notre <a href="politique-confidentialite.html">politique de confidentialité</a>.</p>
+    </div>
+  </div>
+
+  <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+  <script>
+    AOS.init({
+      once: true,
+      offset: 120,
+      duration: 600,
+      easing: 'ease-out-quart'
+    });
+
+    const navToggle = document.getElementById('navToggle');
+    const nav = document.getElementById('mainNav');
+    const body = document.body;
+
+    function closeNav() {
+      nav.classList.remove('is-open');
+      navToggle.setAttribute('aria-expanded', 'false');
+      body.classList.remove('no-scroll');
+    }
+
+    navToggle.addEventListener('click', () => {
+      const isOpen = nav.classList.toggle('is-open');
+      navToggle.setAttribute('aria-expanded', String(isOpen));
+      body.classList.toggle('no-scroll', isOpen);
+    });
+
+    nav.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        if (nav.classList.contains('is-open')) {
+          closeNav();
+        }
+      });
+    });
+
+    const contactModal = document.getElementById('contactModal');
+    const contactForm = document.getElementById('contactForm');
+    const contactSuccess = document.getElementById('contactSuccess');
+    let contactSuccessTimeout;
+
+    function closeContact() {
+      contactModal.classList.remove('is-visible');
+      body.classList.remove('no-scroll');
+      setTimeout(() => {
+        contactModal.hidden = true;
+        contactSuccess.hidden = true;
+        contactForm.reset();
+        if (contactSuccessTimeout) {
+          clearTimeout(contactSuccessTimeout);
+          contactSuccessTimeout = null;
+        }
+      }, 300);
+    }
+
+    function openContact() {
+      closeNav();
+      contactModal.hidden = false;
+      requestAnimationFrame(() => {
+        contactModal.classList.add('is-visible');
+        body.classList.add('no-scroll');
+      });
+    }
+
+    document.querySelectorAll('[data-open-contact]').forEach(btn => btn.addEventListener('click', openContact));
+    contactModal.querySelectorAll('[data-close-contact]').forEach(btn => btn.addEventListener('click', closeContact));
+
+    contactForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const honeypot = contactForm.querySelector('[name="company"]');
+      if (honeypot && honeypot.value.trim() !== '') {
+        return;
+      }
+      contactSuccess.hidden = false;
+      contactSuccess.focus();
+      if (contactSuccessTimeout) {
+        clearTimeout(contactSuccessTimeout);
+      }
+      contactSuccessTimeout = setTimeout(() => {
+        closeContact();
+      }, 4000);
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && contactModal.classList.contains('is-visible')) {
+        closeContact();
+      }
+    });
+
+    const addToCartButtons = document.querySelectorAll('[data-add]');
+    const cartFeedback = document.getElementById('cartFeedback');
+    let cartFeedbackTimeout;
+
+    addToCartButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const label = button.getAttribute('data-name') || 'Stage';
+        cartFeedback.textContent = `${label} ajouté au panier ✔︎`;
+        cartFeedback.hidden = false;
+        cartFeedback.classList.add('is-visible');
+        if (cartFeedbackTimeout) {
+          clearTimeout(cartFeedbackTimeout);
+        }
+        cartFeedbackTimeout = setTimeout(() => {
+          cartFeedback.classList.remove('is-visible');
+          cartFeedback.hidden = true;
+        }, 3200);
+      });
+    });
+
+    const newsletterForm = document.getElementById('newsletterForm');
+    newsletterForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      alert('Merci ! Vous êtes inscrit à la newsletter Tennis Impact.');
+      newsletterForm.reset();
+    });
+
+    document.getElementById('currentYear').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,12 +3,93 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Tennis Impact – Académie premium de tennis</title>
+  <title>Tennis Impact – Académie de tennis premium | Stages &amp; leçons individuelles</title>
+  <meta
+    name="description"
+    content="Académie de tennis haute performance à Bordeaux : stages jeunes intensifs, leçons individuelles et coaching FFT pour progresser vite."
+  />
+  <link rel="canonical" href="https://tennisimpact.fr/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Tennis Impact – Académie de tennis premium" />
+  <meta
+    property="og:description"
+    content="Stages tennis jeunes, leçons individuelles et coaching haute performance à Bordeaux avec l'équipe FFT Tennis Impact."
+  />
+  <meta property="og:url" content="https://tennisimpact.fr/" />
+  <meta property="og:image" content="https://tennisimpact.fr/assets/images/hero-illustration.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Tennis Impact – Académie de tennis premium" />
+  <meta
+    name="twitter:description"
+    content="Progresse plus vite avec les stages et le coaching Tennis Impact à Bordeaux."
+  />
+  <meta name="twitter:image" content="https://tennisimpact.fr/assets/images/hero-illustration.svg" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://unpkg.com/aos@2.3.1/dist/aos.css" />
   <link rel="stylesheet" href="style.css" />
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "LocalBusiness",
+          "@id": "https://tennisimpact.fr/#business",
+          "name": "Tennis Impact",
+          "description": "Académie de tennis haute performance à Bordeaux proposant stages jeunes, leçons individuelles et préparation mentale.",
+          "url": "https://tennisimpact.fr/",
+          "telephone": "+33500000000",
+          "image": "https://tennisimpact.fr/assets/images/hero-illustration.svg",
+          "address": {
+            "@type": "PostalAddress",
+            "streetAddress": "14 avenue du Court Central",
+            "addressLocality": "Bordeaux",
+            "postalCode": "33000",
+            "addressCountry": "FR"
+          },
+          "areaServed": {
+            "@type": "City",
+            "name": "Bordeaux"
+          },
+          "sameAs": [
+            "https://www.facebook.com/tennisimpact",
+            "https://www.instagram.com/tennisimpact"
+          ]
+        },
+        {
+          "@type": "FAQPage",
+          "@id": "https://tennisimpact.fr/#faq",
+          "mainEntity": [
+            {
+              "@type": "Question",
+              "name": "Quels sont les niveaux acceptés ?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Tous les niveaux sont accueillis : initiation, perfectionnement et compétition. Les groupes sont constitués par âge et niveau pour garantir une progression optimale."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Les stages sont-ils ouverts aux adultes ?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Oui, des stages intensifs et des tournées de tournois sont proposés aux adultes souhaitant performer en compétition ou reprendre avec un suivi structuré."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Proposez-vous un hébergement ?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "L'hébergement est disponible en option via nos partenaires premium. Nous nous occupons de la logistique pour que vous puissiez vous concentrer sur votre jeu."
+              }
+            }
+          ]
+        }
+      ]
+    }
+  </script>
 </head>
 <body>
   <header class="navbar" id="top">
@@ -22,14 +103,14 @@
         <span></span>
       </button>
       <nav class="navbar__links" id="mainNav">
-        <a href="#academie" class="nav-link">Notre académie</a>
-        <a href="#stages" class="nav-link">Stages jeunes</a>
-        <a href="#lecons" class="nav-link">Leçons individuelles</a>
-        <a href="#faq" class="nav-link">FAQ</a>
-        <a href="#galerie" class="nav-link">Galerie</a>
+        <a href="notre-academie.html" class="nav-link">Notre académie</a>
+        <a href="stages_jeunes.html" class="nav-link">Stages</a>
+        <a href="lecon_individuelle.html" class="nav-link">Leçons individuelles</a>
+        <a href="faq.html" class="nav-link">FAQ</a>
+        <a href="galerie.html" class="nav-link">Galerie</a>
         <div class="navbar__cta">
-          <a class="btn btn--outline" href="espace_coach.html">Espace coach</a>
-          <button class="btn btn--gold" data-open-contact>Contact</button>
+          <a class="btn btn--gold" href="reserver.html" aria-label="Réserver un stage Tennis Impact">Réserver un stage</a>
+          <button class="btn btn--outline" data-open-contact aria-label="Ouvrir le formulaire de contact Tennis Impact">Contact</button>
         </div>
       </nav>
     </div>
@@ -37,51 +118,64 @@
 
   <main>
     <section class="hero" id="hero">
-      <video class="hero__video" autoplay muted loop playsinline preload="auto" poster="assets/images/hero-illustration.svg" aria-hidden="true">
-        <source src="https://cdn.coverr.co/videos/coverr-tennis-match-9122/1080p.mp4" type="video/mp4" />
-        Votre navigateur ne prend pas en charge la vidéo en arrière-plan.
-      </video>
+      <div class="hero__media" aria-hidden="true">
+        <video
+          class="hero__video"
+          autoplay
+          muted
+          loop
+          playsinline
+          preload="metadata"
+          poster="assets/images/hero-illustration.svg"
+        >
+          <source src="https://cdn.coverr.co/videos/coverr-tennis-serve-1627760544/1080p.webm" type="video/webm" />
+          <source src="https://cdn.coverr.co/videos/coverr-tennis-serve-1627760544/1080p.mp4" type="video/mp4" />
+        </video>
+        <noscript>
+          <img
+            class="hero__poster"
+            src="assets/images/hero-illustration.svg"
+            alt="Joueur de tennis réalisant un service puissant"
+            width="1600"
+            height="900"
+          />
+        </noscript>
+      </div>
+      <div class="hero__overlay" aria-hidden="true"></div>
       <div class="container hero__content" data-aos="fade-up">
-        <p class="hero__subtitle">Académie de tennis haute performance</p>
-        <h1>Performance, plaisir et excellence à chaque échange</h1>
+        <span class="hero__eyebrow">Académie haute performance — Bordeaux</span>
+        <h1>Tennis Impact</h1>
         <p class="hero__description">
-          Programmes signature, staff d'élite et service concierge : Tennis Impact sublime votre jeu avec un accompagnement
-          sur-mesure et une attention à chaque détail.
+          Stages élites &amp; coaching sur-mesure. Technique, physique, mental&nbsp;: votre jeu, accéléré.
         </p>
-        <ul class="hero__pillars" aria-label="Les trois piliers Tennis Impact">
-          <li class="hero__pillar">
-            <span class="hero__pillar-title">Performance</span>
-            <p class="hero__pillar-text">Méthodologie data-driven, ateliers tactiques et préparation physique intégrée.</p>
-          </li>
-          <li class="hero__pillar">
-            <span class="hero__pillar-title">Plaisir</span>
-            <p class="hero__pillar-text">Séances immersives, rythme adapté et ambiance inspirante pour garder le sourire.</p>
-          </li>
-          <li class="hero__pillar">
-            <span class="hero__pillar-title">Signature</span>
-            <p class="hero__pillar-text">Service premium, attention aux détails et suivi continu sur et en dehors du court.</p>
-          </li>
-        </ul>
         <div class="hero__actions">
           <a class="btn btn--gold" href="reserver.html">Réserver un stage</a>
-          <a class="btn btn--ghost" href="reservation_lecon.html">Planifier une leçon</a>
+          <a class="btn btn--outline-light" href="reservation_lecon.html">Planifier une leçon</a>
         </div>
-        <div class="hero__badges" data-aos="fade-up" data-aos-delay="200">
-          <div class="badge">
-            <span class="badge__title">100+</span>
-            <span class="badge__text">joueurs accompagnés</span>
-          </div>
-          <div class="badge">
-            <span class="badge__title">15 ans</span>
-            <span class="badge__text">d'expérience coaching</span>
-          </div>
-          <div class="badge">
-            <span class="badge__title">100% perso</span>
-            <span class="badge__text">programmes individualisés</span>
-          </div>
-        </div>
+        <ul class="hero__pillars" aria-label="Les trois piliers Tennis Impact">
+          <li class="hero__pillar">
+            <span class="hero__pillar-title">Formats intensifs Impact</span>
+            <p class="hero__pillar-text">Stages 3, 5 ou 7 jours avec matchs coachés et suivi quotidien.</p>
+          </li>
+          <li class="hero__pillar">
+            <span class="hero__pillar-title">Coaching certifié FFT</span>
+            <p class="hero__pillar-text">Staff haut niveau, feedback vidéo et plan d’objectifs personnalisé.</p>
+          </li>
+          <li class="hero__pillar">
+            <span class="hero__pillar-title">Méthode Impact 360°</span>
+            <p class="hero__pillar-text">Technique, physique et mental alignés pour un progrès durable.</p>
+          </li>
+        </ul>
+        <a class="hero__discover" href="#academie">Découvrir l’académie</a>
+      </div>
+      <div class="hero__scroll" aria-hidden="true">
+        <span class="hero__scroll-track">
+          <span class="hero__scroll-dot"></span>
+        </span>
+        <span class="hero__scroll-label">Scroll</span>
       </div>
     </section>
+
 
     <section class="section" id="academie">
       <div class="container section__grid">
@@ -104,7 +198,14 @@
           </div>
         </div>
         <div class="section__visual" data-aos="fade-left">
-          <img src="assets/images/stage-1.svg" alt="Joueur sur le court de tennis" />
+          <img
+            src="assets/images/stage-1.svg"
+            alt="Coach Tennis Impact accompagnant un joueur sur le court"
+            width="520"
+            height="360"
+            loading="lazy"
+            decoding="async"
+          />
         </div>
       </div>
     </section>
@@ -118,53 +219,110 @@
         </div>
         <div class="card-grid" data-aos="fade-up" data-aos-delay="150">
           <article class="card">
-            <img src="assets/images/stage-1.svg" alt="Stage multi-sports" class="card__image" />
+            <img
+              src="assets/images/stage-1.svg"
+              alt="Jeune joueur en stage multisport"
+              class="card__image"
+              width="360"
+              height="240"
+              loading="lazy"
+              decoding="async"
+            />
             <div class="card__body">
               <h3>Stage Tennis Multisport</h3>
+              <div class="card__badges" role="list">
+                <span class="card__badge" role="listitem">20h / semaine</span>
+                <span class="card__badge" role="listitem">Dès 8 ans</span>
+                <span class="card__badge" role="listitem">Places limitées</span>
+              </div>
               <p>Une semaine rythmée entre tennis, préparation physique ludique et activités collectives.</p>
-              <ul class="card__list">
-                <li>Du lundi au samedi matin</li>
-                <li>Groupes par âge &amp; niveau</li>
-                <li>Accompagnement mental &amp; nutrition</li>
-              </ul>
+              <p class="card__price">690€ / semaine</p>
               <div class="card__actions">
-                <a class="btn btn--ghost" href="assets/brochure/Brochure Tennis Impact.pdf" download>Télécharger la brochure</a>
-                <a class="btn btn--gold" href="reserver.html">Réserver</a>
+                <a class="btn btn--ghost" href="stages_jeunes.html">En savoir plus</a>
+                <button
+                  class="btn btn--gold"
+                  type="button"
+                  data-add
+                  data-name="Stage Tennis Multisport"
+                  data-price="690"
+                  aria-label="Ajouter le Stage Tennis Multisport au panier"
+                >
+                  Ajouter au panier
+                </button>
               </div>
             </div>
           </article>
           <article class="card">
-            <img src="assets/images/stage-2.svg" alt="Stage intensif" class="card__image" />
+            <img
+              src="assets/images/stage-2.svg"
+              alt="Joueuse pendant un stage intensif"
+              class="card__image"
+              width="360"
+              height="240"
+              loading="lazy"
+              decoding="async"
+            />
             <div class="card__body">
               <h3>Stage Intensif Performance</h3>
+              <div class="card__badges" role="list">
+                <span class="card__badge" role="listitem">25h / semaine</span>
+                <span class="card__badge" role="listitem">Dès 12 ans</span>
+                <span class="card__badge" role="listitem">Analyse vidéo</span>
+              </div>
               <p>Sessions techniques avancées, matchs dirigés et coaching mental pour viser les tournois.</p>
-              <ul class="card__list">
-                <li>25h d'entraînement hebdo</li>
-                <li>Analyse vidéo personnalisée</li>
-                <li>Préparation physique spécifique</li>
-              </ul>
+              <p class="card__price">1 600€ / semaine</p>
               <div class="card__actions">
-                <a class="btn btn--ghost" href="assets/brochure/Brochure Tennis Impact.pdf" download>Télécharger la brochure</a>
-                <a class="btn btn--gold" href="reserver.html">Réserver</a>
+                <a class="btn btn--ghost" href="stages_jeunes.html">En savoir plus</a>
+                <button
+                  class="btn btn--gold"
+                  type="button"
+                  data-add
+                  data-name="Stage Intensif Performance"
+                  data-price="1600"
+                  aria-label="Ajouter le Stage Intensif Performance au panier"
+                >
+                  Ajouter au panier
+                </button>
               </div>
             </div>
           </article>
           <article class="card">
-            <img src="assets/images/stage-3.svg" alt="Tournée de tournois" class="card__image" />
+            <img
+              src="assets/images/stage-3.svg"
+              alt="Joueur coaché pendant une tournée de tournois"
+              class="card__image"
+              width="360"
+              height="240"
+              loading="lazy"
+              decoding="async"
+            />
             <div class="card__body">
               <h3>Tournée &amp; coaching tournois</h3>
+              <div class="card__badges" role="list">
+                <span class="card__badge" role="listitem">Coaching 360°</span>
+                <span class="card__badge" role="listitem">Circuit FFT</span>
+                <span class="card__badge" role="listitem">Support logistique</span>
+              </div>
               <p>Programme de compétition encadré : gestion des matchs, routines et stratégie gagnante.</p>
-              <ul class="card__list">
-                <li>Coaching sur site &amp; feedback live</li>
-                <li>Planning d'objectifs par tournoi</li>
-                <li>Suivi individuel post-compétition</li>
-              </ul>
+              <p class="card__price">2 100€ / tournée</p>
               <div class="card__actions">
-                <a class="btn btn--ghost" href="assets/brochure/Brochure Tennis Impact.pdf" download>Télécharger la brochure</a>
-                <a class="btn btn--gold" href="reserver.html">Réserver</a>
+                <a class="btn btn--ghost" href="stages_jeunes.html">En savoir plus</a>
+                <button
+                  class="btn btn--gold"
+                  type="button"
+                  data-add
+                  data-name="Tournée &amp; coaching tournois"
+                  data-price="2100"
+                  aria-label="Ajouter la tournée de tournois au panier"
+                >
+                  Ajouter au panier
+                </button>
               </div>
             </div>
           </article>
+        </div>
+        <div class="section__footer" data-aos="fade-up" data-aos-delay="220">
+          <a class="btn btn--outline" href="stages_jeunes.html">Découvrir tous les stages</a>
         </div>
       </div>
     </section>
@@ -178,7 +336,15 @@
         </div>
         <div class="card-grid card-grid--compact" data-aos="fade-up" data-aos-delay="100">
           <article class="card card--light">
-            <img src="assets/images/lecon-1.svg" alt="Leçon individuelle" class="card__image" />
+            <img
+              src="assets/images/lecon-1.svg"
+              alt="Coach Tennis Impact en leçon individuelle"
+              class="card__image"
+              width="320"
+              height="220"
+              loading="lazy"
+              decoding="async"
+            />
             <div class="card__body">
               <h3>Session découverte</h3>
               <p class="card__price">45€ / 1h</p>
@@ -187,7 +353,15 @@
             </div>
           </article>
           <article class="card card--light">
-            <img src="assets/images/lecon-2.svg" alt="Pack 5 heures" class="card__image" />
+            <img
+              src="assets/images/lecon-2.svg"
+              alt="Pack de cinq heures de coaching Tennis Impact"
+              class="card__image"
+              width="320"
+              height="220"
+              loading="lazy"
+              decoding="async"
+            />
             <div class="card__body">
               <h3>Pack intensif 5h</h3>
               <p class="card__price">200€ / 5h</p>
@@ -196,7 +370,15 @@
             </div>
           </article>
           <article class="card card--light">
-            <img src="assets/images/lecon-3.svg" alt="Pack 10 heures" class="card__image" />
+            <img
+              src="assets/images/lecon-3.svg"
+              alt="Pack performance de dix heures"
+              class="card__image"
+              width="320"
+              height="220"
+              loading="lazy"
+              decoding="async"
+            />
             <div class="card__body">
               <h3>Pack performance 10h</h3>
               <p class="card__price">380€ / 10h</p>
@@ -205,26 +387,25 @@
             </div>
           </article>
         </div>
+        <div class="section__footer" data-aos="fade-up" data-aos-delay="200">
+          <a class="btn btn--outline" href="lecon_individuelle.html">Voir les packs détaillés</a>
+        </div>
       </div>
     </section>
 
-    <section class="section section--highlight" id="references">
+    <section class="section section--highlight" id="preuves">
       <div class="container references" data-aos="fade-up">
         <div class="references__item">
-          <span class="references__number">+35</span>
-          <span class="references__label">tournois remportés</span>
+          <span class="references__number">+180</span>
+          <span class="references__label">joueurs formés chaque année</span>
         </div>
         <div class="references__item">
-          <span class="references__number">92%</span>
-          <span class="references__label">de joueurs satisfaits</span>
+          <span class="references__number">95%</span>
+          <span class="references__label">de stagiaires recommandent Tennis Impact</span>
         </div>
         <div class="references__item">
-          <span class="references__number">5</span>
-          <span class="references__label">coachs experts FFT</span>
-        </div>
-        <div class="references__item">
-          <span class="references__number">12</span>
-          <span class="references__label">années d'accompagnement</span>
+          <span class="references__number">8</span>
+          <span class="references__label">tournées FFT accompagnées par saison</span>
         </div>
       </div>
     </section>
@@ -269,16 +450,106 @@
           <p>Une sélection de moments forts capturés sur nos courts et lors des stages.</p>
         </div>
         <div class="gallery" data-aos="fade-up" data-aos-delay="120">
-          <img src="assets/images/gallery-1.svg" alt="Jeunes joueurs en stage" />
-          <img src="assets/images/gallery-2.svg" alt="Préparation physique" />
-          <img src="assets/images/gallery-3.svg" alt="Match d'entraînement" />
-          <img src="assets/images/gallery-4.svg" alt="Coaching individuel" />
-          <img src="assets/images/gallery-5.svg" alt="Moment de cohésion d'équipe" />
-          <img src="assets/images/gallery-6.svg" alt="Tennis Impact académie" />
+          <img
+            src="assets/images/gallery-1.svg"
+            alt="Coup droit en extension lors d'un stage intensif"
+            width="360"
+            height="240"
+            loading="lazy"
+            decoding="async"
+          />
+          <img
+            src="assets/images/gallery-2.svg"
+            alt="Séance de préparation physique collective"
+            width="360"
+            height="240"
+            loading="lazy"
+            decoding="async"
+          />
+          <img
+            src="assets/images/gallery-3.svg"
+            alt="Match d'entraînement coaché"
+            width="360"
+            height="240"
+            loading="lazy"
+            decoding="async"
+          />
+          <img
+            src="assets/images/gallery-4.svg"
+            alt="Coaching individuel au filet"
+            width="360"
+            height="240"
+            loading="lazy"
+            decoding="async"
+          />
+          <img
+            src="assets/images/gallery-5.svg"
+            alt="Moment d'équipe pendant un stage Tennis Impact"
+            width="360"
+            height="240"
+            loading="lazy"
+            decoding="async"
+          />
+          <img
+            src="assets/images/gallery-6.svg"
+            alt="Vue du centre Tennis Impact à Bordeaux"
+            width="360"
+            height="240"
+            loading="lazy"
+            decoding="async"
+          />
+        </div>
+        <div class="section__footer" data-aos="fade-up" data-aos-delay="200">
+          <a class="btn btn--outline" href="galerie.html">Explorer la galerie complète</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--testimonials" id="temoignages">
+      <div class="container">
+        <div class="section__intro" data-aos="fade-up">
+          <span class="eyebrow">Ils progressent avec nous</span>
+          <h2>Témoignages &amp; partenaires</h2>
+          <p>Parents, joueurs et marques de référence nous font confiance pour accélérer la progression à Bordeaux.</p>
+        </div>
+        <div class="testimonials" data-aos="fade-up" data-aos-delay="120">
+          <article class="testimonial">
+            <p class="testimonial__quote">
+              «&nbsp;En une semaine de stage intensif, notre fils a gagné deux classements. Les coachs sont exigeants et bienveillants,
+              avec un suivi vidéo bluffant.&nbsp;»
+            </p>
+            <p class="testimonial__author">Camille, maman de Jules (13 ans)</p>
+          </article>
+          <article class="testimonial">
+            <p class="testimonial__quote">
+              «&nbsp;La méthode Impact 360° m’a aidé à gérer la pression en tournoi. On repart avec un plan clair et des routines faciles à appliquer.&nbsp;»
+            </p>
+            <p class="testimonial__author">Léo, joueur 15/2</p>
+          </article>
+          <article class="testimonial">
+            <p class="testimonial__quote">
+              «&nbsp;Organisation premium : transferts, hébergement, communication… tout est fluide pour les familles, même lors des tournées FFT.&nbsp;»
+            </p>
+            <p class="testimonial__author">Sophie, Directrice club partenaire</p>
+          </article>
+        </div>
+        <div class="partners" data-aos="fade-up" data-aos-delay="200">
+          <span class="partners__title">Partenaires officiels</span>
+          <div class="partners__logos" role="list">
+            <span class="partners__logo" role="listitem" aria-label="Wilson">Wilson</span>
+            <span class="partners__logo" role="listitem" aria-label="FFT">FFT</span>
+            <span class="partners__logo" role="listitem" aria-label="Babolat">Babolat</span>
+            <span class="partners__logo" role="listitem" aria-label="Tecnifibre">Tecnifibre</span>
+          </div>
+        </div>
+        <div class="section__footer" data-aos="fade-up" data-aos-delay="260">
+          <a class="btn btn--gold" href="reserver.html">Réserver un stage</a>
         </div>
       </div>
     </section>
   </main>
+
+  <div class="cart-feedback" id="cartFeedback" role="status" aria-live="polite" hidden></div>
 
   <footer class="footer">
     <div class="container footer__grid">
@@ -301,7 +572,7 @@
           <input id="newsletterEmail" type="email" name="email" placeholder="Votre email" required />
           <button type="submit" class="btn btn--gold">S'inscrire</button>
         </form>
-        <p class="footer__note">En vous inscrivant vous acceptez notre <a href="#">politique de confidentialité</a>.</p>
+        <p class="footer__note">En vous inscrivant vous acceptez notre <a href="politique-confidentialite.html">politique de confidentialité</a>.</p>
       </div>
     </div>
     <div class="footer__bottom">
@@ -333,20 +604,79 @@
         <label for="contactMessage">Message</label>
         <textarea id="contactMessage" name="message" rows="4" placeholder="Parlez-nous de vos objectifs" required></textarea>
 
+        <label class="sr-only" for="contactStageType">Type de demande</label>
+        <select id="contactStageType" name="stage" required>
+          <option value="" disabled selected>Type de stage</option>
+          <option value="intensif">Stage intensif</option>
+          <option value="tournoi">Tournée tournois</option>
+          <option value="lecon">Leçon individuelle</option>
+        </select>
+
+        <div class="sr-only" aria-hidden="true">
+          <label for="contactCompany">Ne pas remplir ce champ</label>
+          <input id="contactCompany" type="text" name="company" tabindex="-1" autocomplete="off" />
+        </div>
+
         <button type="submit" class="btn btn--gold btn--full">Envoyer</button>
       </form>
-      <p class="contact-modal__success" id="contactSuccess" hidden>Merci ! Votre message a bien été envoyé.</p>
+      <p class="contact-modal__success" id="contactSuccess" role="status" aria-live="polite" tabindex="-1" hidden>
+        Merci, votre demande a bien été envoyée.
+      </p>
+      <p class="contact-modal__rgpd">Vos données ne sont utilisées que pour répondre à votre demande. Consultez notre <a href="politique-confidentialite.html">politique de confidentialité</a>.</p>
     </div>
   </div>
 
   <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
   <script>
-    AOS.init({
-      once: true,
-      offset: 120,
-      duration: 600,
-      easing: 'ease-out-quart'
-    });
+    const supportsMatchMedia = typeof window.matchMedia === 'function';
+    const prefersReducedMotion = supportsMatchMedia
+      ? window.matchMedia('(prefers-reduced-motion: reduce)')
+      : { matches: false };
+
+    function initAOSWithPreferences() {
+      if (!window.AOS) {
+        return;
+      }
+
+      window.AOS.init({
+        once: true,
+        offset: 120,
+        duration: prefersReducedMotion.matches ? 0 : 600,
+        easing: 'ease-out-quart',
+        disable: prefersReducedMotion.matches
+      });
+
+      if (prefersReducedMotion.matches && typeof window.AOS.disable === 'function') {
+        window.AOS.disable();
+      }
+    }
+
+    initAOSWithPreferences();
+
+    const handleMotionPreferenceChange = (event) => {
+      if (!window.AOS) {
+        return;
+      }
+
+      if (event.matches) {
+        if (typeof window.AOS.disable === 'function') {
+          window.AOS.disable();
+        }
+      } else {
+        initAOSWithPreferences();
+        if (typeof window.AOS.refreshHard === 'function') {
+          window.AOS.refreshHard();
+        }
+      }
+    };
+
+    if (supportsMatchMedia) {
+      if (prefersReducedMotion.addEventListener) {
+        prefersReducedMotion.addEventListener('change', handleMotionPreferenceChange);
+      } else if (prefersReducedMotion.addListener) {
+        prefersReducedMotion.addListener(handleMotionPreferenceChange);
+      }
+    }
 
     const navToggle = document.getElementById('navToggle');
     const nav = document.getElementById('mainNav');
@@ -375,6 +705,7 @@
     const contactModal = document.getElementById('contactModal');
     const contactForm = document.getElementById('contactForm');
     const contactSuccess = document.getElementById('contactSuccess');
+    let contactSuccessTimeout;
 
     function openContact() {
       closeNav();
@@ -392,6 +723,10 @@
         contactModal.hidden = true;
         contactSuccess.hidden = true;
         contactForm.reset();
+        if (contactSuccessTimeout) {
+          clearTimeout(contactSuccessTimeout);
+          contactSuccessTimeout = null;
+        }
       }, 300);
     }
 
@@ -400,7 +735,18 @@
 
     contactForm.addEventListener('submit', (event) => {
       event.preventDefault();
+      const honeypot = contactForm.querySelector('[name="company"]');
+      if (honeypot && honeypot.value.trim() !== '') {
+        return;
+      }
       contactSuccess.hidden = false;
+      contactSuccess.focus();
+      if (contactSuccessTimeout) {
+        clearTimeout(contactSuccessTimeout);
+      }
+      contactSuccessTimeout = setTimeout(() => {
+        closeContact();
+      }, 4000);
     });
 
     document.addEventListener('keydown', (event) => {
@@ -421,6 +767,26 @@
       if (index === 0) {
         button.click();
       }
+    });
+
+    const addToCartButtons = document.querySelectorAll('[data-add]');
+    const cartFeedback = document.getElementById('cartFeedback');
+    let cartFeedbackTimeout;
+
+    addToCartButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const label = button.getAttribute('data-name') || 'Stage';
+        cartFeedback.textContent = `${label} ajouté au panier ✔︎`;
+        cartFeedback.hidden = false;
+        cartFeedback.classList.add('is-visible');
+        if (cartFeedbackTimeout) {
+          clearTimeout(cartFeedbackTimeout);
+        }
+        cartFeedbackTimeout = setTimeout(() => {
+          cartFeedback.classList.remove('is-visible');
+          cartFeedback.hidden = true;
+        }, 3200);
+      });
     });
 
     const newsletterForm = document.getElementById('newsletterForm');

--- a/politique-confidentialite.html
+++ b/politique-confidentialite.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politique de confidentialité – Tennis Impact</title>
+  <meta
+    name="description"
+    content="Découvrez comment Tennis Impact collecte, utilise et protège vos données personnelles."
+  />
+  <link rel="canonical" href="https://tennisimpact.fr/politique-confidentialite" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Politique de confidentialité – Tennis Impact" />
+  <meta
+    property="og:description"
+    content="Informations sur la gestion des données personnelles par l'académie Tennis Impact à Bordeaux."
+  />
+  <meta property="og:url" content="https://tennisimpact.fr/politique-confidentialite" />
+  <meta property="og:image" content="https://tennisimpact.fr/assets/images/hero-illustration.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Politique de confidentialité – Tennis Impact" />
+  <meta
+    name="twitter:description"
+    content="Politique de confidentialité des stages et leçons Tennis Impact."
+  />
+  <meta name="twitter:image" content="https://tennisimpact.fr/assets/images/hero-illustration.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="navbar" id="top">
+    <div class="navbar__container">
+      <a class="navbar__brand" href="index.html" aria-label="Accueil Tennis Impact">
+        <img src="assets/images/logo.svg" alt="Tennis Impact" />
+      </a>
+      <button class="navbar__toggle" id="navToggle" aria-expanded="false" aria-controls="mainNav" aria-label="Ouvrir le menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <nav class="navbar__links" id="mainNav">
+        <a href="notre-academie.html" class="nav-link">Notre académie</a>
+        <a href="stages_jeunes.html" class="nav-link">Stages</a>
+        <a href="lecon_individuelle.html" class="nav-link">Leçons individuelles</a>
+        <a href="faq.html" class="nav-link">FAQ</a>
+        <a href="galerie.html" class="nav-link">Galerie</a>
+        <div class="navbar__cta">
+          <a class="btn btn--gold" href="reserver.html" aria-label="Réserver un stage Tennis Impact">Réserver un stage</a>
+          <button class="btn btn--outline" data-open-contact aria-label="Ouvrir le formulaire de contact Tennis Impact">Contact</button>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section" id="privacy">
+      <div class="container" data-aos="fade-up">
+        <span class="eyebrow">Confidentialité</span>
+        <h1>Politique de confidentialité Tennis Impact</h1>
+        <p>Dernière mise à jour : janvier 2024</p>
+        <div class="privacy__content">
+          <h2>1. Responsable du traitement</h2>
+          <p>Tennis Impact, 14 avenue du Court Central, 33000 Bordeaux. Contact : <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a>.</p>
+
+          <h2>2. Données collectées</h2>
+          <p>Nous collectons les informations transmises via les formulaires de contact, de réservation et d'inscription newsletter : identité, coordonnées, préférences de stage et messages.</p>
+
+          <h2>3. Finalités</h2>
+          <p>Les données servent à répondre aux demandes, planifier les stages, assurer le suivi pédagogique, envoyer des informations liées à l'académie et respecter nos obligations légales.</p>
+
+          <h2>4. Base légale</h2>
+          <p>Le traitement est fondé sur le consentement pour les demandes volontaires et sur l'exécution d'un contrat pour les réservations confirmées.</p>
+
+          <h2>5. Durée de conservation</h2>
+          <p>Les données liées aux demandes sont conservées 24 mois, les dossiers de stages jusqu'à 5 ans après la fin de la prestation, sauf obligation légale contraire.</p>
+
+          <h2>6. Destinataires</h2>
+          <p>Seuls les coachs Tennis Impact et nos partenaires logistiques (hébergement, transport) accèdent aux données strictement nécessaires.</p>
+
+          <h2>7. Droits</h2>
+          <p>Vous disposez d'un droit d'accès, de rectification, d'effacement, de limitation et d'opposition. Adressez votre demande à <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a>.</p>
+
+          <h2>8. Sécurité</h2>
+          <p>Nous mettons en place des mesures techniques et organisationnelles pour protéger vos informations : hébergement sécurisé, accès restreint, chiffrement des paiements via Stripe.</p>
+
+          <h2>9. Cookies &amp; analytics</h2>
+          <p>Nous utilisons des cookies essentiels au fonctionnement du site et des outils de mesure d'audience anonymisés. Vous pouvez paramétrer vos préférences via les réglages de votre navigateur.</p>
+
+          <h2>10. Contact CNIL</h2>
+          <p>Si vous estimez que vos droits ne sont pas respectés, vous pouvez introduire une réclamation auprès de la CNIL : <a href="https://www.cnil.fr">www.cnil.fr</a>.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <div class="cart-feedback" id="cartFeedback" role="status" aria-live="polite" hidden></div>
+
+  <footer class="footer">
+    <div class="container footer__grid">
+      <div>
+        <img src="assets/images/logo.svg" alt="Tennis Impact" class="footer__logo" />
+        <p>Académie de tennis premium à Bordeaux. Stages jeunes, coaching individuel et préparation de compétitions.</p>
+      </div>
+      <div>
+        <h3>Nous contacter</h3>
+        <ul class="footer__list">
+          <li><a href="tel:+33500000000">+33 (0)5 00 00 00 00</a></li>
+          <li><a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a></li>
+          <li>14 avenue du Court Central – 33000 Bordeaux</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Newsletter</h3>
+        <form class="newsletter" id="newsletterForm">
+          <label class="sr-only" for="newsletterEmail">Votre email</label>
+          <input id="newsletterEmail" type="email" name="email" placeholder="Votre email" required />
+          <button type="submit" class="btn btn--gold">S'inscrire</button>
+        </form>
+        <p class="footer__note">En vous inscrivant vous acceptez notre <a href="politique-confidentialite.html">politique de confidentialité</a>.</p>
+      </div>
+    </div>
+    <div class="footer__bottom">
+      <div class="container footer__bottom-inner">
+        <p>© <span id="currentYear"></span> Tennis Impact. Tous droits réservés.</p>
+        <div class="footer__links">
+          <a href="#">Mentions légales</a>
+          <a href="#">Conditions générales</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <div class="contact-modal" id="contactModal" role="dialog" aria-modal="true" aria-labelledby="contactTitle" hidden>
+    <div class="contact-modal__overlay" data-close-contact></div>
+    <div class="contact-modal__content">
+      <button class="contact-modal__close" type="button" data-close-contact aria-label="Fermer le formulaire">
+        ×
+      </button>
+      <h2 id="contactTitle">Contactez-nous</h2>
+      <p>Parlez-nous de votre projet tennistique, nous vous répondons sous 24h.</p>
+      <form id="contactForm" class="contact-form">
+        <label for="contactName">Nom complet</label>
+        <input id="contactName" name="name" type="text" placeholder="Votre nom" required />
+
+        <label for="contactEmail">Email</label>
+        <input id="contactEmail" name="email" type="email" placeholder="Votre email" required />
+
+        <label for="contactMessage">Message</label>
+        <textarea id="contactMessage" name="message" rows="4" placeholder="Parlez-nous de vos objectifs" required></textarea>
+
+        <label class="sr-only" for="contactStageType">Type de demande</label>
+        <select id="contactStageType" name="stage" required>
+          <option value="" disabled selected>Type de stage</option>
+          <option value="intensif">Stage intensif</option>
+          <option value="tournoi">Tournée tournois</option>
+          <option value="lecon">Leçon individuelle</option>
+        </select>
+
+        <div class="sr-only" aria-hidden="true">
+          <label for="contactCompany">Ne pas remplir ce champ</label>
+          <input id="contactCompany" type="text" name="company" tabindex="-1" autocomplete="off" />
+        </div>
+
+        <button type="submit" class="btn btn--gold btn--full">Envoyer</button>
+      </form>
+      <p class="contact-modal__success" id="contactSuccess" role="status" aria-live="polite" tabindex="-1" hidden>
+        Merci, votre demande a bien été envoyée.
+      </p>
+      <p class="contact-modal__rgpd">Vos données ne sont utilisées que pour répondre à votre demande. Consultez notre <a href="politique-confidentialite.html">politique de confidentialité</a>.</p>
+    </div>
+  </div>
+
+  <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+  <script>
+    AOS.init({
+      once: true,
+      offset: 120,
+      duration: 600,
+      easing: 'ease-out-quart'
+    });
+
+    const navToggle = document.getElementById('navToggle');
+    const nav = document.getElementById('mainNav');
+    const body = document.body;
+
+    function closeNav() {
+      nav.classList.remove('is-open');
+      navToggle.setAttribute('aria-expanded', 'false');
+      body.classList.remove('no-scroll');
+    }
+
+    navToggle.addEventListener('click', () => {
+      const isOpen = nav.classList.toggle('is-open');
+      navToggle.setAttribute('aria-expanded', String(isOpen));
+      body.classList.toggle('no-scroll', isOpen);
+    });
+
+    nav.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        if (nav.classList.contains('is-open')) {
+          closeNav();
+        }
+      });
+    });
+
+    const contactModal = document.getElementById('contactModal');
+    const contactForm = document.getElementById('contactForm');
+    const contactSuccess = document.getElementById('contactSuccess');
+    let contactSuccessTimeout;
+
+    function closeContact() {
+      contactModal.classList.remove('is-visible');
+      body.classList.remove('no-scroll');
+      setTimeout(() => {
+        contactModal.hidden = true;
+        contactSuccess.hidden = true;
+        contactForm.reset();
+        if (contactSuccessTimeout) {
+          clearTimeout(contactSuccessTimeout);
+          contactSuccessTimeout = null;
+        }
+      }, 300);
+    }
+
+    function openContact() {
+      closeNav();
+      contactModal.hidden = false;
+      requestAnimationFrame(() => {
+        contactModal.classList.add('is-visible');
+        body.classList.add('no-scroll');
+      });
+    }
+
+    document.querySelectorAll('[data-open-contact]').forEach(btn => btn.addEventListener('click', openContact));
+    contactModal.querySelectorAll('[data-close-contact]').forEach(btn => btn.addEventListener('click', closeContact));
+
+    contactForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const honeypot = contactForm.querySelector('[name="company"]');
+      if (honeypot && honeypot.value.trim() !== '') {
+        return;
+      }
+      contactSuccess.hidden = false;
+      contactSuccess.focus();
+      if (contactSuccessTimeout) {
+        clearTimeout(contactSuccessTimeout);
+      }
+      contactSuccessTimeout = setTimeout(() => {
+        closeContact();
+      }, 4000);
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && contactModal.classList.contains('is-visible')) {
+        closeContact();
+      }
+    });
+
+    const cartFeedback = document.getElementById('cartFeedback');
+    if (cartFeedback) {
+      cartFeedback.hidden = true;
+    }
+
+    const newsletterForm = document.getElementById('newsletterForm');
+    newsletterForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      alert('Merci ! Vous êtes inscrit à la newsletter Tennis Impact.');
+      newsletterForm.reset();
+    });
+
+    document.getElementById('currentYear').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -32,6 +32,28 @@ body {
   scroll-behavior: smooth;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  html:focus-within {
+    scroll-behavior: auto;
+  }
+
+  body {
+    scroll-behavior: auto;
+  }
+
+  .hero__video {
+    display: none;
+  }
+}
+
 img {
   display: block;
   max-width: 100%;
@@ -117,6 +139,19 @@ ul {
 .btn--outline:focus-visible {
   background: rgba(13, 27, 42, 0.08);
   border-color: rgba(13, 27, 42, 0.35);
+}
+
+.btn--outline-light {
+  border-color: rgba(255, 255, 255, 0.45);
+  color: rgba(255, 255, 255, 0.9);
+  background: transparent;
+}
+
+.btn--outline-light:hover,
+.btn--outline-light:focus-visible {
+  border-color: rgba(255, 255, 255, 0.75);
+  color: var(--color-gold);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .section--dark .btn--ghost {
@@ -212,73 +247,104 @@ ul {
   min-height: 100vh;
   display: grid;
   align-items: center;
+  justify-items: center;
+  padding: clamp(6rem, 12vw, 8rem) 0 clamp(5rem, 12vw, 7rem);
   color: var(--color-white);
-  padding: 6rem 0 5rem;
+  text-align: center;
   overflow: hidden;
+  background: linear-gradient(135deg, rgba(5, 10, 15, 0.92), rgba(13, 27, 42, 0.88));
+}
+
+.hero__media {
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
 }
 
 .hero__video {
-  position: absolute;
-  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
-  z-index: -2;
+  filter: saturate(1.1);
 }
 
-.hero::after {
-  content: '';
+.hero__poster {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.hero__overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(7, 17, 29, 0.78), rgba(17, 41, 68, 0.58));
+  background: linear-gradient(125deg, rgba(5, 10, 15, 0.8), rgba(13, 27, 42, 0.55));
   z-index: -1;
+  mix-blend-mode: multiply;
+  pointer-events: none;
 }
 
 .hero__content {
-  position: relative;
-  z-index: 1;
-  max-width: 720px;
+  width: min(780px, 100% - 32px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
-.hero__subtitle {
-  text-transform: uppercase;
-  letter-spacing: 4px;
-  font-size: 0.85rem;
+.hero__eyebrow {
+  display: inline-block;
+  margin-bottom: 1.2rem;
+  font-size: 0.82rem;
   font-weight: 600;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
   color: rgba(249, 214, 92, 0.8);
-  margin-bottom: 1.5rem;
 }
 
 .hero h1 {
   font-family: var(--font-heading);
-  font-size: clamp(2.8rem, 4vw, 3.8rem);
-  line-height: 1.1;
-  margin-bottom: 1.5rem;
+  font-size: clamp(3.2rem, 6vw, 4.8rem);
+  line-height: 1.05;
+  margin-bottom: 1.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .hero__description {
-  font-size: 1.05rem;
-  color: rgba(255, 255, 255, 0.82);
-  margin-bottom: 2rem;
+  font-size: clamp(1.05rem, 2.3vw, 1.25rem);
+  color: rgba(255, 255, 255, 0.85);
+  margin-bottom: clamp(2.3rem, 5vw, 3rem);
+  max-width: 44rem;
+}
+
+.hero__actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.1rem;
+  flex-wrap: wrap;
+  margin-bottom: clamp(2.2rem, 5vw, 3rem);
 }
 
 .hero__pillars {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   gap: 1.25rem;
   list-style: none;
   padding: 0;
-  margin: 0 0 2.5rem;
+  margin: 0 0 clamp(2rem, 5vw, 2.8rem);
+  width: 100%;
 }
 
 .hero__pillar {
   position: relative;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 20px;
-  padding: 1.4rem 1.6rem 1.6rem;
-  backdrop-filter: blur(10px);
-  transition: transform 0.4s ease, border-color 0.4s ease, background 0.4s ease;
+  padding: 1.5rem 1.6rem;
+  border-radius: 1.1rem;
+  background: rgba(8, 19, 32, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  box-shadow: 0 24px 60px rgba(4, 10, 16, 0.45);
+  backdrop-filter: blur(12px);
+  text-align: left;
 }
 
 .hero__pillar::before {
@@ -291,14 +357,13 @@ ul {
   -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
+  pointer-events: none;
   opacity: 0;
   transition: opacity 0.4s ease;
 }
 
 .hero__pillar:hover {
   transform: translateY(-6px);
-  border-color: rgba(249, 214, 92, 0.55);
-  background: rgba(255, 255, 255, 0.12);
 }
 
 .hero__pillar:hover::before {
@@ -308,52 +373,100 @@ ul {
 .hero__pillar-title {
   display: block;
   font-family: var(--font-heading);
-  font-size: 1.25rem;
-  margin-bottom: 0.75rem;
+  font-size: 1.2rem;
+  margin-bottom: 0.6rem;
   color: var(--color-gold);
-  letter-spacing: 0.5px;
+  letter-spacing: 0.04em;
 }
 
 .hero__pillar-text {
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.78);
-  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.75);
+  line-height: 1.6;
 }
 
-.hero__actions {
-  display: flex;
+.hero__discover {
+  display: inline-flex;
   align-items: center;
-  gap: 1rem;
-  flex-wrap: wrap;
-  margin-bottom: 2.5rem;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
+  transition: color 0.3s ease;
 }
 
-.hero__badges {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
+.hero__discover::after {
+  content: '';
+  width: 36px;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.45);
+  transition: transform 0.3s ease, background 0.3s ease;
 }
 
-.badge {
-  backdrop-filter: blur(8px);
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 20px;
-  padding: 1rem 1.4rem;
-  min-width: 150px;
-  text-align: center;
-}
-
-.badge__title {
-  display: block;
-  font-size: 1.4rem;
-  font-weight: 700;
+.hero__discover:hover,
+.hero__discover:focus-visible {
   color: var(--color-gold);
 }
 
-.badge__text {
-  font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.76);
+.hero__discover:hover::after,
+.hero__discover:focus-visible::after {
+  transform: translateX(4px);
+  background: var(--color-gold);
+}
+
+.hero__scroll {
+  position: absolute;
+  left: 50%;
+  bottom: clamp(2rem, 5vw, 3rem);
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+}
+
+.hero__scroll-track {
+  width: 26px;
+  height: 44px;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-radius: 999px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 6px 0;
+  overflow: hidden;
+}
+
+.hero__scroll-dot {
+  width: 6px;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+  animation: heroScroll 2.2s infinite;
+}
+
+@keyframes heroScroll {
+  0% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  50% {
+    transform: translateY(12px);
+    opacity: 0.4;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.hero__scroll-label {
+  font-size: inherit;
 }
 
 .section {
@@ -368,6 +481,10 @@ ul {
 
 .section--highlight {
   background: linear-gradient(90deg, rgba(249, 214, 92, 0.12), rgba(249, 214, 92, 0.35));
+}
+
+.section--testimonials {
+  background: linear-gradient(135deg, rgba(248, 251, 255, 0.95), rgba(255, 248, 230, 0.9));
 }
 
 .section__grid {
@@ -396,6 +513,10 @@ ul {
   color: rgba(13, 27, 42, 0.72);
 }
 
+.section--testimonials .section__intro p {
+  color: rgba(13, 27, 42, 0.68);
+}
+
 .section--dark .section__intro p {
   color: rgba(255, 255, 255, 0.75);
 }
@@ -405,6 +526,16 @@ ul {
   display: flex;
   gap: 1rem;
   flex-wrap: wrap;
+}
+
+.section__footer {
+  margin-top: clamp(2.2rem, 5vw, 3rem);
+  display: flex;
+  justify-content: center;
+}
+
+.section__footer .btn {
+  min-width: 220px;
 }
 
 .section__visual img {
@@ -497,6 +628,23 @@ ul {
   color: var(--color-navy);
 }
 
+.card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.card__badge {
+  background: rgba(249, 214, 92, 0.16);
+  color: var(--color-navy-700);
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
 .card--light h3 {
   color: var(--color-navy-700);
 }
@@ -564,6 +712,77 @@ ul {
   display: flex;
   gap: 0.6rem;
   flex-wrap: wrap;
+}
+
+.testimonials {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.testimonial {
+  background: var(--color-white);
+  border-radius: var(--radius-card);
+  padding: 2rem;
+  box-shadow: 0 18px 32px rgba(13, 27, 42, 0.08);
+  border: 1px solid rgba(13, 27, 42, 0.06);
+}
+
+.testimonial__quote {
+  font-size: 1rem;
+  color: rgba(13, 27, 42, 0.75);
+  line-height: 1.7;
+}
+
+.testimonial__author {
+  margin-top: 1.5rem;
+  font-weight: 600;
+  color: var(--color-navy-700);
+}
+
+.partners {
+  margin-top: clamp(2.5rem, 6vw, 3.5rem);
+  text-align: center;
+  display: grid;
+  gap: 1.2rem;
+}
+
+.partners__title {
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(13, 27, 42, 0.55);
+}
+
+.partners__logos {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.partners__logo {
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(13, 27, 42, 0.12);
+  background: rgba(255, 255, 255, 0.85);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-navy-700);
+}
+
+.privacy__content {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 2rem;
+  color: rgba(13, 27, 42, 0.72);
+}
+
+.privacy__content h2 {
+  font-family: var(--font-heading);
+  font-size: 1.4rem;
+  color: var(--color-navy-700);
 }
 
 .card-grid--compact .card__image {
@@ -776,7 +995,8 @@ ul {
 }
 
 .contact-form input,
-.contact-form textarea {
+.contact-form textarea,
+.contact-form select {
   width: 100%;
   padding: 0.9rem 1rem;
   border-radius: 12px;
@@ -796,6 +1016,35 @@ ul {
   padding: 1rem 1.2rem;
   color: var(--color-navy-700);
   font-weight: 500;
+}
+
+.contact-modal__rgpd {
+  font-size: 0.85rem;
+  color: rgba(13, 27, 42, 0.6);
+}
+
+.contact-modal__rgpd a {
+  text-decoration: underline;
+}
+
+.cart-feedback {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  background: var(--color-navy);
+  color: var(--color-white);
+  padding: 1rem 1.4rem;
+  border-radius: 16px;
+  box-shadow: var(--shadow-strong);
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 1500;
+}
+
+.cart-feedback.is-visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 @media (max-width: 960px) {
@@ -835,25 +1084,17 @@ ul {
   }
 
   .hero {
+    justify-items: center;
     text-align: center;
   }
 
-  .hero__actions {
-    justify-content: center;
+  .hero__content {
+    margin: 0 auto;
   }
 
   .hero__pillars {
-    margin-left: auto;
-    margin-right: auto;
-    text-align: left;
-  }
-
-  .hero__pillar {
-    text-align: left;
-  }
-
-  .hero__badges {
-    justify-content: center;
+    margin-inline: auto;
+    max-width: 560px;
   }
 
   .section__content p {
@@ -879,13 +1120,21 @@ ul {
     padding: 5rem 0 4rem;
   }
 
-  .hero__description {
-    font-size: 0.95rem;
+  .hero__pillars {
+    grid-template-columns: 1fr;
+    gap: 1rem;
   }
 
-  .badge {
-    min-width: 120px;
-    padding: 0.9rem 1.1rem;
+  .hero__description {
+    font-size: 0.98rem;
+  }
+
+  .hero__scroll-track {
+    height: 38px;
+  }
+
+  .hero__scroll-dot {
+    height: 8px;
   }
 
   .card__body {


### PR DESCRIPTION
## Summary
- resolve the homepage conflict by centering the hero on the Tennis Impact title, dual CTAs, and premium messaging requested
- refresh the hero styles with the background video overlay, glass-effect pillar cards, discover link, and scroll indicator to keep the section clean and premium on all breakpoints

## Testing
- not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68e60e1199b88325b770694fe99ea45b