### PR TITLE
Implement full-screen mobile navigation overlay

### DIFF
--- a/espace_coach.html
+++ b/espace_coach.html
@@ -20,16 +20,26 @@
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primaryNav">
         <span></span>
       </button>
-      <nav class="site-nav" id="primaryNav">
-        <a class="site-nav__link" href="index.html">Accueil</a>
-        <a class="site-nav__link" href="notre-academie.html">Académie</a>
-        <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
-        <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
-        <a class="site-nav__link" href="galerie.html">Galerie</a>
-        <a class="site-nav__link" href="faq.html">FAQ</a>
-        <div class="site-nav__cta">
-          <a class="btn btn--outline" href="reservation_lecon.html">Planifier une leçon</a>
-          <a class="btn btn--primary" href="#formulaire">Devenir partenaire</a>
+      <nav class="site-nav" id="primaryNav" aria-label="Navigation principale">
+        <div class="site-nav__content">
+          <div class="site-nav__links">
+            <a class="site-nav__link" href="index.html">Accueil</a>
+            <a class="site-nav__link" href="notre-academie.html">Académie</a>
+            <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
+            <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
+            <a class="site-nav__link" href="galerie.html">Galerie</a>
+            <a class="site-nav__link" href="faq.html">FAQ</a>
+          </div>
+          <div class="site-nav__cta">
+            <a class="btn btn--outline" href="reservation_lecon.html">Planifier une leçon</a>
+            <a class="btn btn--primary" href="#formulaire">Devenir partenaire</a>
+          </div>
+          <div class="site-nav__meta">
+            <strong>Tennis Impact Academy</strong>
+            <a href="tel:+33556000000">+33 (0)5 56 00 00 00</a>
+            <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a>
+            <span>14 avenue du Court Central · Bordeaux</span>
+          </div>
         </div>
       </nav>
     </div>
@@ -176,18 +186,89 @@
     const header = document.querySelector('.site-header');
     const toggle = document.querySelector('.nav-toggle');
     const nav = document.getElementById('primaryNav');
-    toggle.addEventListener('click', () => {
-      const isOpen = header.classList.toggle('is-open');
-      toggle.setAttribute('aria-expanded', isOpen);
-    });
-    nav.querySelectorAll('a').forEach((link) => {
-      link.addEventListener('click', () => {
+    const body = document.body;
+    const focusableSelectors = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled])';
+    let lastFocusedElement = null;
+
+    const getFocusableElements = () =>
+      nav ? Array.from(nav.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('disabled')) : [];
+
+    const closeMenu = () => {
+      if (!header || !toggle) return;
+      header.classList.remove('is-open');
+      body.classList.remove('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
+    };
+
+    const openMenu = () => {
+      if (!header || !toggle) return;
+      lastFocusedElement = document.activeElement;
+      header.classList.add('is-open');
+      body.classList.add('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      const focusable = getFocusableElements();
+      if (focusable.length) {
+        focusable[0].focus();
+      }
+    };
+
+    if (toggle && nav) {
+      toggle.addEventListener('click', () => {
         if (header.classList.contains('is-open')) {
-          header.classList.remove('is-open');
-          toggle.setAttribute('aria-expanded', 'false');
+          closeMenu();
+        } else {
+          openMenu();
         }
       });
-    });
+
+      nav.querySelectorAll('a').forEach((link) =>
+        link.addEventListener('click', () => {
+          closeMenu();
+        })
+      );
+
+      const handleDesktopChange = (event) => {
+        if (event.matches) {
+          closeMenu();
+        }
+      };
+
+      const mediaQuery = window.matchMedia('(min-width: 1025px)');
+      handleDesktopChange(mediaQuery);
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', handleDesktopChange);
+      } else {
+        mediaQuery.addListener(handleDesktopChange);
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (!header.classList.contains('is-open')) return;
+
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeMenu();
+          toggle.focus();
+        } else if (event.key === 'Tab') {
+          const focusable = getFocusableElements();
+          if (!focusable.length) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      });
+    }
+
     document.getElementById('currentYear').textContent = new Date().getFullYear();
   </script>
 </body>

--- a/faq.html
+++ b/faq.html
@@ -20,25 +20,26 @@
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primaryNav">
         <span></span>
       </button>
-      <nav class="site-nav" id="primaryNav">
-        <a class="site-nav__link" href="index.html">Accueil</a>
-        <a class="site-nav__link" href="notre-academie.html">Académie</a>
-        <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
-        <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
-        <a class="site-nav__link" href="galerie.html">Galerie</a>
-        <a class="site-nav__link is-active" href="faq.html">FAQ</a>
-        <div class="site-nav__cta">
-          <a class="btn btn--outline" href="reserver.html">Réserver</a>
-          <a class="btn btn--primary" href="reservation_lecon.html">Parler à un coach</a>
-      <nav class="navbar__links" id="mainNav">
-        <a href="notre-academie.html" class="nav-link">Notre académie</a>
-        <a href="stages_jeunes.html" class="nav-link">Stages</a>
-        <a href="lecon_individuelle.html" class="nav-link">Leçons individuelles</a>
-        <a href="faq.html" class="nav-link" aria-current="page">FAQ</a>
-        <a href="galerie.html" class="nav-link">Galerie</a>
-        <div class="navbar__cta">
-          <a class="btn btn--gold" href="reserver.html" aria-label="Réserver un stage Tennis Impact">Réserver un stage</a>
-          <button class="btn btn--outline-light" data-open-contact aria-label="Ouvrir le formulaire de contact Tennis Impact">Contact</button>
+      <nav class="site-nav" id="primaryNav" aria-label="Navigation principale">
+        <div class="site-nav__content">
+          <div class="site-nav__links">
+            <a class="site-nav__link" href="index.html">Accueil</a>
+            <a class="site-nav__link" href="notre-academie.html">Académie</a>
+            <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
+            <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
+            <a class="site-nav__link" href="galerie.html">Galerie</a>
+            <a class="site-nav__link is-active" href="faq.html" aria-current="page">FAQ</a>
+          </div>
+          <div class="site-nav__cta">
+            <a class="btn btn--outline" href="reserver.html">Réserver</a>
+            <a class="btn btn--primary" href="reservation_lecon.html">Parler à un coach</a>
+          </div>
+          <div class="site-nav__meta">
+            <strong>Tennis Impact Academy</strong>
+            <a href="tel:+33556000000">+33 (0)5 56 00 00 00</a>
+            <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a>
+            <span>14 avenue du Court Central · Bordeaux</span>
+          </div>
         </div>
       </nav>
     </div>
@@ -150,18 +151,88 @@
     const header = document.querySelector('.site-header');
     const toggle = document.querySelector('.nav-toggle');
     const nav = document.getElementById('primaryNav');
-    toggle.addEventListener('click', () => {
-      const isOpen = header.classList.toggle('is-open');
-      toggle.setAttribute('aria-expanded', isOpen);
-    });
-    nav.querySelectorAll('a').forEach((link) => {
-      link.addEventListener('click', () => {
+    const body = document.body;
+    const focusableSelectors = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled])';
+    let lastFocusedElement = null;
+
+    const getFocusableElements = () =>
+      nav ? Array.from(nav.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('disabled')) : [];
+
+    const closeMenu = () => {
+      if (!header || !toggle) return;
+      header.classList.remove('is-open');
+      body.classList.remove('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
+    };
+
+    const openMenu = () => {
+      if (!header || !toggle) return;
+      lastFocusedElement = document.activeElement;
+      header.classList.add('is-open');
+      body.classList.add('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      const focusable = getFocusableElements();
+      if (focusable.length) {
+        focusable[0].focus();
+      }
+    };
+
+    if (toggle && nav) {
+      toggle.addEventListener('click', () => {
         if (header.classList.contains('is-open')) {
-          header.classList.remove('is-open');
-          toggle.setAttribute('aria-expanded', 'false');
+          closeMenu();
+        } else {
+          openMenu();
         }
       });
-    });
+
+      nav.querySelectorAll('a').forEach((link) =>
+        link.addEventListener('click', () => {
+          closeMenu();
+        })
+      );
+
+      const handleDesktopChange = (event) => {
+        if (event.matches) {
+          closeMenu();
+        }
+      };
+
+      const mediaQuery = window.matchMedia('(min-width: 1025px)');
+      handleDesktopChange(mediaQuery);
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', handleDesktopChange);
+      } else {
+        mediaQuery.addListener(handleDesktopChange);
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (!header.classList.contains('is-open')) return;
+
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeMenu();
+          toggle.focus();
+        } else if (event.key === 'Tab') {
+          const focusable = getFocusableElements();
+          if (!focusable.length) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      });
+    }
 
     document.querySelectorAll('.accordion__button').forEach((button) => {
       button.addEventListener('click', () => {

--- a/galerie.html
+++ b/galerie.html
@@ -20,25 +20,26 @@
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primaryNav">
         <span></span>
       </button>
-      <nav class="site-nav" id="primaryNav">
-        <a class="site-nav__link" href="index.html">Accueil</a>
-        <a class="site-nav__link" href="notre-academie.html">Académie</a>
-        <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
-        <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
-        <a class="site-nav__link is-active" href="galerie.html">Galerie</a>
-        <a class="site-nav__link" href="faq.html">FAQ</a>
-        <div class="site-nav__cta">
-          <a class="btn btn--outline" href="reserver.html">Réserver</a>
-          <a class="btn btn--primary" href="reservation_lecon.html">Parler à un coach</a>
-      <nav class="navbar__links" id="mainNav">
-        <a href="notre-academie.html" class="nav-link">Notre académie</a>
-        <a href="stages_jeunes.html" class="nav-link">Stages</a>
-        <a href="lecon_individuelle.html" class="nav-link">Leçons individuelles</a>
-        <a href="faq.html" class="nav-link">FAQ</a>
-        <a href="galerie.html" class="nav-link" aria-current="page">Galerie</a>
-        <div class="navbar__cta">
-          <a class="btn btn--gold" href="reserver.html" aria-label="Réserver un stage Tennis Impact">Réserver un stage</a>
-          <button class="btn btn--outline-light" data-open-contact aria-label="Ouvrir le formulaire de contact Tennis Impact">Contact</button>
+      <nav class="site-nav" id="primaryNav" aria-label="Navigation principale">
+        <div class="site-nav__content">
+          <div class="site-nav__links">
+            <a class="site-nav__link" href="index.html">Accueil</a>
+            <a class="site-nav__link" href="notre-academie.html">Académie</a>
+            <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
+            <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
+            <a class="site-nav__link is-active" href="galerie.html" aria-current="page">Galerie</a>
+            <a class="site-nav__link" href="faq.html">FAQ</a>
+          </div>
+          <div class="site-nav__cta">
+            <a class="btn btn--outline" href="reserver.html">Réserver</a>
+            <a class="btn btn--primary" href="reservation_lecon.html">Parler à un coach</a>
+          </div>
+          <div class="site-nav__meta">
+            <strong>Tennis Impact Academy</strong>
+            <a href="tel:+33556000000">+33 (0)5 56 00 00 00</a>
+            <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a>
+            <span>14 avenue du Court Central · Bordeaux</span>
+          </div>
         </div>
       </nav>
     </div>
@@ -237,18 +238,89 @@
     const header = document.querySelector('.site-header');
     const toggle = document.querySelector('.nav-toggle');
     const nav = document.getElementById('primaryNav');
-    toggle.addEventListener('click', () => {
-      const isOpen = header.classList.toggle('is-open');
-      toggle.setAttribute('aria-expanded', isOpen);
-    });
-    nav.querySelectorAll('a').forEach((link) => {
-      link.addEventListener('click', () => {
+    const body = document.body;
+    const focusableSelectors = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled])';
+    let lastFocusedElement = null;
+
+    const getFocusableElements = () =>
+      nav ? Array.from(nav.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('disabled')) : [];
+
+    const closeMenu = () => {
+      if (!header || !toggle) return;
+      header.classList.remove('is-open');
+      body.classList.remove('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
+    };
+
+    const openMenu = () => {
+      if (!header || !toggle) return;
+      lastFocusedElement = document.activeElement;
+      header.classList.add('is-open');
+      body.classList.add('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      const focusable = getFocusableElements();
+      if (focusable.length) {
+        focusable[0].focus();
+      }
+    };
+
+    if (toggle && nav) {
+      toggle.addEventListener('click', () => {
         if (header.classList.contains('is-open')) {
-          header.classList.remove('is-open');
-          toggle.setAttribute('aria-expanded', 'false');
+          closeMenu();
+        } else {
+          openMenu();
         }
       });
-    });
+
+      nav.querySelectorAll('a').forEach((link) =>
+        link.addEventListener('click', () => {
+          closeMenu();
+        })
+      );
+
+      const handleDesktopChange = (event) => {
+        if (event.matches) {
+          closeMenu();
+        }
+      };
+
+      const mediaQuery = window.matchMedia('(min-width: 1025px)');
+      handleDesktopChange(mediaQuery);
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', handleDesktopChange);
+      } else {
+        mediaQuery.addListener(handleDesktopChange);
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (!header.classList.contains('is-open')) return;
+
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeMenu();
+          toggle.focus();
+        } else if (event.key === 'Tab') {
+          const focusable = getFocusableElements();
+          if (!focusable.length) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      });
+    }
+
     document.getElementById('currentYear').textContent = new Date().getFullYear();
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -27,17 +27,27 @@
         <span></span>
       </button>
       <nav class="site-nav" id="primaryNav" aria-label="Navigation principale">
-        <a class="site-nav__link is-active" href="#top">Accueil</a>
-        <a class="site-nav__link" href="#signature">Signature</a>
-        <a class="site-nav__link" href="#studio">Studio</a>
-        <a class="site-nav__link" href="#offres">Offres</a>
-        <a class="site-nav__link" href="#experience">Méthode</a>
-        <a class="site-nav__link" href="#equipe">Équipe</a>
-        <a class="site-nav__link" href="#temoignages">Avis</a>
-        <a class="site-nav__link" href="#contact">Contact</a>
-        <div class="site-nav__cta">
-          <a class="btn btn--outline" href="#experience">Découvrir</a>
-          <a class="btn btn--gold" href="https://www.pausepilates.fr/#lien-inscription-aux-cours">Réserver un cours</a>
+        <div class="site-nav__content">
+          <div class="site-nav__links">
+            <a class="site-nav__link is-active" href="#top">Accueil</a>
+            <a class="site-nav__link" href="#signature">Signature</a>
+            <a class="site-nav__link" href="#studio">Studio</a>
+            <a class="site-nav__link" href="#offres">Offres</a>
+            <a class="site-nav__link" href="#experience">Méthode</a>
+            <a class="site-nav__link" href="#equipe">Équipe</a>
+            <a class="site-nav__link" href="#temoignages">Avis</a>
+            <a class="site-nav__link" href="#contact">Contact</a>
+          </div>
+          <div class="site-nav__cta">
+            <a class="btn btn--outline" href="#experience">Découvrir</a>
+            <a class="btn btn--gold" href="https://www.pausepilates.fr/#lien-inscription-aux-cours">Réserver un cours</a>
+          </div>
+          <div class="site-nav__meta">
+            <strong>Studio Pause Pilates Colmar</strong>
+            <a href="tel:+33389000000">+33 (0)3 89 00 00 00</a>
+            <a href="mailto:bonjour@pausepilates.fr">bonjour@pausepilates.fr</a>
+            <span>15 rue des Marchands · Colmar</span>
+          </div>
         </div>
       </nav>
     </div>
@@ -435,20 +445,89 @@
     const header = document.querySelector('.site-header');
     const toggle = document.querySelector('.nav-toggle');
     const nav = document.getElementById('primaryNav');
-    if (toggle) {
+    const body = document.body;
+    const focusableSelectors = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled])';
+    let lastFocusedElement = null;
+
+    const getFocusableElements = () =>
+      nav ? Array.from(nav.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('disabled')) : [];
+
+    const closeMenu = () => {
+      if (!header || !toggle) return;
+      header.classList.remove('is-open');
+      body.classList.remove('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
+    };
+
+    const openMenu = () => {
+      if (!header || !toggle) return;
+      lastFocusedElement = document.activeElement;
+      header.classList.add('is-open');
+      body.classList.add('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      const focusable = getFocusableElements();
+      if (focusable.length) {
+        focusable[0].focus();
+      }
+    };
+
+    if (toggle && nav) {
       toggle.addEventListener('click', () => {
-        const expanded = header.classList.toggle('is-open');
-        toggle.setAttribute('aria-expanded', expanded);
+        if (header.classList.contains('is-open')) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
       });
-    }
-    if (nav) {
+
       nav.querySelectorAll('a').forEach((link) =>
         link.addEventListener('click', () => {
-          header.classList.remove('is-open');
-          toggle.setAttribute('aria-expanded', 'false');
+          closeMenu();
         })
       );
+
+      const handleDesktopChange = (event) => {
+        if (event.matches) {
+          closeMenu();
+        }
+      };
+
+      const mediaQuery = window.matchMedia('(min-width: 1025px)');
+      handleDesktopChange(mediaQuery);
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', handleDesktopChange);
+      } else {
+        mediaQuery.addListener(handleDesktopChange);
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (!header.classList.contains('is-open')) return;
+
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeMenu();
+          toggle.focus();
+        } else if (event.key === 'Tab') {
+          const focusable = getFocusableElements();
+          if (!focusable.length) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      });
     }
+
     const year = document.getElementById('currentYear');
     if (year) {
       year.textContent = new Date().getFullYear();

--- a/lecon_individuelle.html
+++ b/lecon_individuelle.html
@@ -20,16 +20,26 @@
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primaryNav">
         <span></span>
       </button>
-      <nav class="site-nav" id="primaryNav">
-        <a class="site-nav__link" href="index.html">Accueil</a>
-        <a class="site-nav__link" href="notre-academie.html">Académie</a>
-        <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
-        <a class="site-nav__link is-active" href="lecon_individuelle.html">Coaching privé</a>
-        <a class="site-nav__link" href="galerie.html">Galerie</a>
-        <a class="site-nav__link" href="faq.html">FAQ</a>
-        <div class="site-nav__cta">
-          <a class="btn btn--outline" href="reserver.html">Réserver</a>
-          <a class="btn btn--primary" href="reservation_lecon.html">Planifier une session</a>
+      <nav class="site-nav" id="primaryNav" aria-label="Navigation principale">
+        <div class="site-nav__content">
+          <div class="site-nav__links">
+            <a class="site-nav__link" href="index.html">Accueil</a>
+            <a class="site-nav__link" href="notre-academie.html">Académie</a>
+            <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
+            <a class="site-nav__link is-active" href="lecon_individuelle.html" aria-current="page">Coaching privé</a>
+            <a class="site-nav__link" href="galerie.html">Galerie</a>
+            <a class="site-nav__link" href="faq.html">FAQ</a>
+          </div>
+          <div class="site-nav__cta">
+            <a class="btn btn--outline" href="reserver.html">Réserver</a>
+            <a class="btn btn--primary" href="reservation_lecon.html">Planifier une session</a>
+          </div>
+          <div class="site-nav__meta">
+            <strong>Tennis Impact Academy</strong>
+            <a href="tel:+33556000000">+33 (0)5 56 00 00 00</a>
+            <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a>
+            <span>14 avenue du Court Central · Bordeaux</span>
+          </div>
         </div>
       </nav>
     </div>
@@ -216,18 +226,89 @@
     const header = document.querySelector('.site-header');
     const toggle = document.querySelector('.nav-toggle');
     const nav = document.getElementById('primaryNav');
-    toggle.addEventListener('click', () => {
-      const isOpen = header.classList.toggle('is-open');
-      toggle.setAttribute('aria-expanded', isOpen);
-    });
-    nav.querySelectorAll('a').forEach((link) => {
-      link.addEventListener('click', () => {
+    const body = document.body;
+    const focusableSelectors = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled])';
+    let lastFocusedElement = null;
+
+    const getFocusableElements = () =>
+      nav ? Array.from(nav.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('disabled')) : [];
+
+    const closeMenu = () => {
+      if (!header || !toggle) return;
+      header.classList.remove('is-open');
+      body.classList.remove('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
+    };
+
+    const openMenu = () => {
+      if (!header || !toggle) return;
+      lastFocusedElement = document.activeElement;
+      header.classList.add('is-open');
+      body.classList.add('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      const focusable = getFocusableElements();
+      if (focusable.length) {
+        focusable[0].focus();
+      }
+    };
+
+    if (toggle && nav) {
+      toggle.addEventListener('click', () => {
         if (header.classList.contains('is-open')) {
-          header.classList.remove('is-open');
-          toggle.setAttribute('aria-expanded', 'false');
+          closeMenu();
+        } else {
+          openMenu();
         }
       });
-    });
+
+      nav.querySelectorAll('a').forEach((link) =>
+        link.addEventListener('click', () => {
+          closeMenu();
+        })
+      );
+
+      const handleDesktopChange = (event) => {
+        if (event.matches) {
+          closeMenu();
+        }
+      };
+
+      const mediaQuery = window.matchMedia('(min-width: 1025px)');
+      handleDesktopChange(mediaQuery);
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', handleDesktopChange);
+      } else {
+        mediaQuery.addListener(handleDesktopChange);
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (!header.classList.contains('is-open')) return;
+
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeMenu();
+          toggle.focus();
+        } else if (event.key === 'Tab') {
+          const focusable = getFocusableElements();
+          if (!focusable.length) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      });
+    }
+
     document.getElementById('currentYear').textContent = new Date().getFullYear();
   </script>
 </body>

--- a/notre-academie.html
+++ b/notre-academie.html
@@ -20,16 +20,26 @@
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primaryNav">
         <span></span>
       </button>
-      <nav class="site-nav" id="primaryNav">
-        <a class="site-nav__link" href="index.html">Accueil</a>
-        <a class="site-nav__link is-active" href="notre-academie.html">Académie</a>
-        <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
-        <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
-        <a class="site-nav__link" href="galerie.html">Galerie</a>
-        <a class="site-nav__link" href="faq.html">FAQ</a>
-        <div class="site-nav__cta">
-          <a class="btn btn--outline" href="reserver.html">Réserver</a>
-          <a class="btn btn--primary" href="reservation_lecon.html">Parler à un coach</a>
+      <nav class="site-nav" id="primaryNav" aria-label="Navigation principale">
+        <div class="site-nav__content">
+          <div class="site-nav__links">
+            <a class="site-nav__link" href="index.html">Accueil</a>
+            <a class="site-nav__link is-active" href="notre-academie.html" aria-current="page">Académie</a>
+            <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
+            <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
+            <a class="site-nav__link" href="galerie.html">Galerie</a>
+            <a class="site-nav__link" href="faq.html">FAQ</a>
+          </div>
+          <div class="site-nav__cta">
+            <a class="btn btn--outline" href="reserver.html">Réserver</a>
+            <a class="btn btn--primary" href="reservation_lecon.html">Parler à un coach</a>
+          </div>
+          <div class="site-nav__meta">
+            <strong>Tennis Impact Academy</strong>
+            <a href="tel:+33556000000">+33 (0)5 56 00 00 00</a>
+            <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a>
+            <span>14 avenue du Court Central · Bordeaux</span>
+          </div>
         </div>
       </nav>
     </div>
@@ -198,18 +208,89 @@
     const header = document.querySelector('.site-header');
     const toggle = document.querySelector('.nav-toggle');
     const nav = document.getElementById('primaryNav');
-    toggle.addEventListener('click', () => {
-      const isOpen = header.classList.toggle('is-open');
-      toggle.setAttribute('aria-expanded', isOpen);
-    });
-    nav.querySelectorAll('a').forEach((link) => {
-      link.addEventListener('click', () => {
+    const body = document.body;
+    const focusableSelectors = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled])';
+    let lastFocusedElement = null;
+
+    const getFocusableElements = () =>
+      nav ? Array.from(nav.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('disabled')) : [];
+
+    const closeMenu = () => {
+      if (!header || !toggle) return;
+      header.classList.remove('is-open');
+      body.classList.remove('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
+    };
+
+    const openMenu = () => {
+      if (!header || !toggle) return;
+      lastFocusedElement = document.activeElement;
+      header.classList.add('is-open');
+      body.classList.add('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      const focusable = getFocusableElements();
+      if (focusable.length) {
+        focusable[0].focus();
+      }
+    };
+
+    if (toggle && nav) {
+      toggle.addEventListener('click', () => {
         if (header.classList.contains('is-open')) {
-          header.classList.remove('is-open');
-          toggle.setAttribute('aria-expanded', 'false');
+          closeMenu();
+        } else {
+          openMenu();
         }
       });
-    });
+
+      nav.querySelectorAll('a').forEach((link) =>
+        link.addEventListener('click', () => {
+          closeMenu();
+        })
+      );
+
+      const handleDesktopChange = (event) => {
+        if (event.matches) {
+          closeMenu();
+        }
+      };
+
+      const mediaQuery = window.matchMedia('(min-width: 1025px)');
+      handleDesktopChange(mediaQuery);
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', handleDesktopChange);
+      } else {
+        mediaQuery.addListener(handleDesktopChange);
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (!header.classList.contains('is-open')) return;
+
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeMenu();
+          toggle.focus();
+        } else if (event.key === 'Tab') {
+          const focusable = getFocusableElements();
+          if (!focusable.length) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      });
+    }
+
     document.getElementById('currentYear').textContent = new Date().getFullYear();
   </script>
 </body>

--- a/politique-confidentialite.html
+++ b/politique-confidentialite.html
@@ -20,25 +20,26 @@
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primaryNav">
         <span></span>
       </button>
-      <nav class="site-nav" id="primaryNav">
-        <a class="site-nav__link" href="index.html">Accueil</a>
-        <a class="site-nav__link" href="notre-academie.html">Académie</a>
-        <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
-        <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
-        <a class="site-nav__link" href="galerie.html">Galerie</a>
-        <a class="site-nav__link" href="faq.html">FAQ</a>
-        <div class="site-nav__cta">
-          <a class="btn btn--outline" href="reserver.html">Réserver</a>
-          <a class="btn btn--primary" href="reservation_lecon.html">Parler à un coach</a>
-      <nav class="navbar__links" id="mainNav">
-        <a href="notre-academie.html" class="nav-link">Notre académie</a>
-        <a href="stages_jeunes.html" class="nav-link">Stages</a>
-        <a href="lecon_individuelle.html" class="nav-link">Leçons individuelles</a>
-        <a href="faq.html" class="nav-link">FAQ</a>
-        <a href="galerie.html" class="nav-link">Galerie</a>
-        <div class="navbar__cta">
-          <a class="btn btn--gold" href="reserver.html" aria-label="Réserver un stage Tennis Impact">Réserver un stage</a>
-          <button class="btn btn--outline-light" data-open-contact aria-label="Ouvrir le formulaire de contact Tennis Impact">Contact</button>
+      <nav class="site-nav" id="primaryNav" aria-label="Navigation principale">
+        <div class="site-nav__content">
+          <div class="site-nav__links">
+            <a class="site-nav__link" href="index.html">Accueil</a>
+            <a class="site-nav__link" href="notre-academie.html">Académie</a>
+            <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
+            <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
+            <a class="site-nav__link" href="galerie.html">Galerie</a>
+            <a class="site-nav__link" href="faq.html">FAQ</a>
+          </div>
+          <div class="site-nav__cta">
+            <a class="btn btn--outline" href="reserver.html">Réserver</a>
+            <a class="btn btn--primary" href="reservation_lecon.html">Parler à un coach</a>
+          </div>
+          <div class="site-nav__meta">
+            <strong>Tennis Impact Academy</strong>
+            <a href="tel:+33556000000">+33 (0)5 56 00 00 00</a>
+            <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a>
+            <span>14 avenue du Court Central · Bordeaux</span>
+          </div>
         </div>
       </nav>
     </div>
@@ -139,18 +140,89 @@
     const header = document.querySelector('.site-header');
     const toggle = document.querySelector('.nav-toggle');
     const nav = document.getElementById('primaryNav');
-    toggle.addEventListener('click', () => {
-      const isOpen = header.classList.toggle('is-open');
-      toggle.setAttribute('aria-expanded', isOpen);
-    });
-    nav.querySelectorAll('a').forEach((link) => {
-      link.addEventListener('click', () => {
+    const body = document.body;
+    const focusableSelectors = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled])';
+    let lastFocusedElement = null;
+
+    const getFocusableElements = () =>
+      nav ? Array.from(nav.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('disabled')) : [];
+
+    const closeMenu = () => {
+      if (!header || !toggle) return;
+      header.classList.remove('is-open');
+      body.classList.remove('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
+    };
+
+    const openMenu = () => {
+      if (!header || !toggle) return;
+      lastFocusedElement = document.activeElement;
+      header.classList.add('is-open');
+      body.classList.add('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      const focusable = getFocusableElements();
+      if (focusable.length) {
+        focusable[0].focus();
+      }
+    };
+
+    if (toggle && nav) {
+      toggle.addEventListener('click', () => {
         if (header.classList.contains('is-open')) {
-          header.classList.remove('is-open');
-          toggle.setAttribute('aria-expanded', 'false');
+          closeMenu();
+        } else {
+          openMenu();
         }
       });
-    });
+
+      nav.querySelectorAll('a').forEach((link) =>
+        link.addEventListener('click', () => {
+          closeMenu();
+        })
+      );
+
+      const handleDesktopChange = (event) => {
+        if (event.matches) {
+          closeMenu();
+        }
+      };
+
+      const mediaQuery = window.matchMedia('(min-width: 1025px)');
+      handleDesktopChange(mediaQuery);
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', handleDesktopChange);
+      } else {
+        mediaQuery.addListener(handleDesktopChange);
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (!header.classList.contains('is-open')) return;
+
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeMenu();
+          toggle.focus();
+        } else if (event.key === 'Tab') {
+          const focusable = getFocusableElements();
+          if (!focusable.length) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      });
+    }
+
     document.getElementById('currentYear').textContent = new Date().getFullYear();
   </script>
 </body>

--- a/reservation_lecon.html
+++ b/reservation_lecon.html
@@ -20,16 +20,26 @@
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primaryNav">
         <span></span>
       </button>
-      <nav class="site-nav" id="primaryNav">
-        <a class="site-nav__link" href="index.html">Accueil</a>
-        <a class="site-nav__link" href="notre-academie.html">Académie</a>
-        <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
-        <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
-        <a class="site-nav__link" href="galerie.html">Galerie</a>
-        <a class="site-nav__link" href="faq.html">FAQ</a>
-        <div class="site-nav__cta">
-          <a class="btn btn--outline" href="reserver.html">Réserver un stage</a>
-          <a class="btn btn--primary" href="reservation_lecon.html">Planifier une leçon</a>
+      <nav class="site-nav" id="primaryNav" aria-label="Navigation principale">
+        <div class="site-nav__content">
+          <div class="site-nav__links">
+            <a class="site-nav__link" href="index.html">Accueil</a>
+            <a class="site-nav__link" href="notre-academie.html">Académie</a>
+            <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
+            <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
+            <a class="site-nav__link" href="galerie.html">Galerie</a>
+            <a class="site-nav__link" href="faq.html">FAQ</a>
+          </div>
+          <div class="site-nav__cta">
+            <a class="btn btn--outline" href="reserver.html">Réserver un stage</a>
+            <a class="btn btn--primary" href="reservation_lecon.html">Planifier une leçon</a>
+          </div>
+          <div class="site-nav__meta">
+            <strong>Tennis Impact Academy</strong>
+            <a href="tel:+33556000000">+33 (0)5 56 00 00 00</a>
+            <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a>
+            <span>14 avenue du Court Central · Bordeaux</span>
+          </div>
         </div>
       </nav>
     </div>
@@ -154,18 +164,89 @@
     const header = document.querySelector('.site-header');
     const toggle = document.querySelector('.nav-toggle');
     const nav = document.getElementById('primaryNav');
-    toggle.addEventListener('click', () => {
-      const isOpen = header.classList.toggle('is-open');
-      toggle.setAttribute('aria-expanded', isOpen);
-    });
-    nav.querySelectorAll('a').forEach((link) => {
-      link.addEventListener('click', () => {
+    const body = document.body;
+    const focusableSelectors = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled])';
+    let lastFocusedElement = null;
+
+    const getFocusableElements = () =>
+      nav ? Array.from(nav.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('disabled')) : [];
+
+    const closeMenu = () => {
+      if (!header || !toggle) return;
+      header.classList.remove('is-open');
+      body.classList.remove('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
+    };
+
+    const openMenu = () => {
+      if (!header || !toggle) return;
+      lastFocusedElement = document.activeElement;
+      header.classList.add('is-open');
+      body.classList.add('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      const focusable = getFocusableElements();
+      if (focusable.length) {
+        focusable[0].focus();
+      }
+    };
+
+    if (toggle && nav) {
+      toggle.addEventListener('click', () => {
         if (header.classList.contains('is-open')) {
-          header.classList.remove('is-open');
-          toggle.setAttribute('aria-expanded', 'false');
+          closeMenu();
+        } else {
+          openMenu();
         }
       });
-    });
+
+      nav.querySelectorAll('a').forEach((link) =>
+        link.addEventListener('click', () => {
+          closeMenu();
+        })
+      );
+
+      const handleDesktopChange = (event) => {
+        if (event.matches) {
+          closeMenu();
+        }
+      };
+
+      const mediaQuery = window.matchMedia('(min-width: 1025px)');
+      handleDesktopChange(mediaQuery);
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', handleDesktopChange);
+      } else {
+        mediaQuery.addListener(handleDesktopChange);
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (!header.classList.contains('is-open')) return;
+
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeMenu();
+          toggle.focus();
+        } else if (event.key === 'Tab') {
+          const focusable = getFocusableElements();
+          if (!focusable.length) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      });
+    }
+
     document.getElementById('currentYear').textContent = new Date().getFullYear();
   </script>
 </body>

--- a/reserver.html
+++ b/reserver.html
@@ -20,16 +20,26 @@
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primaryNav">
         <span></span>
       </button>
-      <nav class="site-nav" id="primaryNav">
-        <a class="site-nav__link" href="index.html">Accueil</a>
-        <a class="site-nav__link" href="notre-academie.html">Académie</a>
-        <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
-        <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
-        <a class="site-nav__link" href="galerie.html">Galerie</a>
-        <a class="site-nav__link" href="faq.html">FAQ</a>
-        <div class="site-nav__cta">
-          <a class="btn btn--outline" href="reservation_lecon.html">Coaching privé</a>
-          <a class="btn btn--primary" href="reserver.html">Réserver un stage</a>
+      <nav class="site-nav" id="primaryNav" aria-label="Navigation principale">
+        <div class="site-nav__content">
+          <div class="site-nav__links">
+            <a class="site-nav__link" href="index.html">Accueil</a>
+            <a class="site-nav__link" href="notre-academie.html">Académie</a>
+            <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
+            <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
+            <a class="site-nav__link" href="galerie.html">Galerie</a>
+            <a class="site-nav__link" href="faq.html">FAQ</a>
+          </div>
+          <div class="site-nav__cta">
+            <a class="btn btn--outline" href="reservation_lecon.html">Coaching privé</a>
+            <a class="btn btn--primary" href="reserver.html">Réserver un stage</a>
+          </div>
+          <div class="site-nav__meta">
+            <strong>Tennis Impact Academy</strong>
+            <a href="tel:+33556000000">+33 (0)5 56 00 00 00</a>
+            <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a>
+            <span>14 avenue du Court Central · Bordeaux</span>
+          </div>
         </div>
       </nav>
     </div>
@@ -179,18 +189,89 @@
     const header = document.querySelector('.site-header');
     const toggle = document.querySelector('.nav-toggle');
     const nav = document.getElementById('primaryNav');
-    toggle.addEventListener('click', () => {
-      const isOpen = header.classList.toggle('is-open');
-      toggle.setAttribute('aria-expanded', isOpen);
-    });
-    nav.querySelectorAll('a').forEach((link) => {
-      link.addEventListener('click', () => {
+    const body = document.body;
+    const focusableSelectors = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled])';
+    let lastFocusedElement = null;
+
+    const getFocusableElements = () =>
+      nav ? Array.from(nav.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('disabled')) : [];
+
+    const closeMenu = () => {
+      if (!header || !toggle) return;
+      header.classList.remove('is-open');
+      body.classList.remove('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
+    };
+
+    const openMenu = () => {
+      if (!header || !toggle) return;
+      lastFocusedElement = document.activeElement;
+      header.classList.add('is-open');
+      body.classList.add('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      const focusable = getFocusableElements();
+      if (focusable.length) {
+        focusable[0].focus();
+      }
+    };
+
+    if (toggle && nav) {
+      toggle.addEventListener('click', () => {
         if (header.classList.contains('is-open')) {
-          header.classList.remove('is-open');
-          toggle.setAttribute('aria-expanded', 'false');
+          closeMenu();
+        } else {
+          openMenu();
         }
       });
-    });
+
+      nav.querySelectorAll('a').forEach((link) =>
+        link.addEventListener('click', () => {
+          closeMenu();
+        })
+      );
+
+      const handleDesktopChange = (event) => {
+        if (event.matches) {
+          closeMenu();
+        }
+      };
+
+      const mediaQuery = window.matchMedia('(min-width: 1025px)');
+      handleDesktopChange(mediaQuery);
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', handleDesktopChange);
+      } else {
+        mediaQuery.addListener(handleDesktopChange);
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (!header.classList.contains('is-open')) return;
+
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeMenu();
+          toggle.focus();
+        } else if (event.key === 'Tab') {
+          const focusable = getFocusableElements();
+          if (!focusable.length) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      });
+    }
+
     document.getElementById('currentYear').textContent = new Date().getFullYear();
   </script>
 </body>

--- a/reserver_popup_hostens.html
+++ b/reserver_popup_hostens.html
@@ -20,14 +20,25 @@
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primaryNav">
         <span></span>
       </button>
-      <nav class="site-nav" id="primaryNav">
-        <a class="site-nav__link" href="index.html">Accueil</a>
-        <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
-        <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
-        <a class="site-nav__link" href="galerie.html">Galerie</a>
-        <div class="site-nav__cta">
-          <a class="btn btn--outline" href="reserver.html">Réserver</a>
-          <a class="btn btn--primary" href="reservation_lecon.html">Parler à un coach</a>
+      <nav class="site-nav" id="primaryNav" aria-label="Navigation principale">
+        <div class="site-nav__content">
+          <div class="site-nav__links">
+            <a class="site-nav__link" href="index.html">Accueil</a>
+            <a class="site-nav__link" href="stages_jeunes.html">Stages</a>
+            <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
+            <a class="site-nav__link" href="galerie.html">Galerie</a>
+            <a class="site-nav__link" href="faq.html">FAQ</a>
+          </div>
+          <div class="site-nav__cta">
+            <a class="btn btn--outline" href="reserver.html">Réserver</a>
+            <a class="btn btn--primary" href="reservation_lecon.html">Parler à un coach</a>
+          </div>
+          <div class="site-nav__meta">
+            <strong>Tennis Impact Academy</strong>
+            <a href="tel:+33556000000">+33 (0)5 56 00 00 00</a>
+            <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a>
+            <span>14 avenue du Court Central · Bordeaux</span>
+          </div>
         </div>
       </nav>
     </div>
@@ -157,18 +168,89 @@
     const header = document.querySelector('.site-header');
     const toggle = document.querySelector('.nav-toggle');
     const nav = document.getElementById('primaryNav');
-    toggle.addEventListener('click', () => {
-      const isOpen = header.classList.toggle('is-open');
-      toggle.setAttribute('aria-expanded', isOpen);
-    });
-    nav.querySelectorAll('a').forEach((link) => {
-      link.addEventListener('click', () => {
+    const body = document.body;
+    const focusableSelectors = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled])';
+    let lastFocusedElement = null;
+
+    const getFocusableElements = () =>
+      nav ? Array.from(nav.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('disabled')) : [];
+
+    const closeMenu = () => {
+      if (!header || !toggle) return;
+      header.classList.remove('is-open');
+      body.classList.remove('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
+    };
+
+    const openMenu = () => {
+      if (!header || !toggle) return;
+      lastFocusedElement = document.activeElement;
+      header.classList.add('is-open');
+      body.classList.add('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      const focusable = getFocusableElements();
+      if (focusable.length) {
+        focusable[0].focus();
+      }
+    };
+
+    if (toggle && nav) {
+      toggle.addEventListener('click', () => {
         if (header.classList.contains('is-open')) {
-          header.classList.remove('is-open');
-          toggle.setAttribute('aria-expanded', 'false');
+          closeMenu();
+        } else {
+          openMenu();
         }
       });
-    });
+
+      nav.querySelectorAll('a').forEach((link) =>
+        link.addEventListener('click', () => {
+          closeMenu();
+        })
+      );
+
+      const handleDesktopChange = (event) => {
+        if (event.matches) {
+          closeMenu();
+        }
+      };
+
+      const mediaQuery = window.matchMedia('(min-width: 1025px)');
+      handleDesktopChange(mediaQuery);
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', handleDesktopChange);
+      } else {
+        mediaQuery.addListener(handleDesktopChange);
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (!header.classList.contains('is-open')) return;
+
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeMenu();
+          toggle.focus();
+        } else if (event.key === 'Tab') {
+          const focusable = getFocusableElements();
+          if (!focusable.length) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      });
+    }
+
     document.getElementById('currentYear').textContent = new Date().getFullYear();
   </script>
 </body>

--- a/stages_jeunes.html
+++ b/stages_jeunes.html
@@ -190,16 +190,26 @@
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primaryNav">
         <span></span>
       </button>
-      <nav class="site-nav" id="primaryNav">
-        <a class="site-nav__link" href="index.html">Accueil</a>
-        <a class="site-nav__link" href="notre-academie.html">Académie</a>
-        <a class="site-nav__link is-active" href="stages_jeunes.html">Stages</a>
-        <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
-        <a class="site-nav__link" href="galerie.html">Galerie</a>
-        <a class="site-nav__link" href="faq.html">FAQ</a>
-        <div class="site-nav__cta">
-          <a class="btn btn--outline" href="reserver.html">Réserver</a>
-          <a class="btn btn--primary" href="reservation_lecon.html">Parler à un coach</a>
+      <nav class="site-nav" id="primaryNav" aria-label="Navigation principale">
+        <div class="site-nav__content">
+          <div class="site-nav__links">
+            <a class="site-nav__link" href="index.html">Accueil</a>
+            <a class="site-nav__link" href="notre-academie.html">Académie</a>
+            <a class="site-nav__link is-active" href="stages_jeunes.html" aria-current="page">Stages</a>
+            <a class="site-nav__link" href="lecon_individuelle.html">Coaching privé</a>
+            <a class="site-nav__link" href="galerie.html">Galerie</a>
+            <a class="site-nav__link" href="faq.html">FAQ</a>
+          </div>
+          <div class="site-nav__cta">
+            <a class="btn btn--outline" href="reserver.html">Réserver</a>
+            <a class="btn btn--primary" href="reservation_lecon.html">Parler à un coach</a>
+          </div>
+          <div class="site-nav__meta">
+            <strong>Tennis Impact Academy</strong>
+            <a href="tel:+33556000000">+33 (0)5 56 00 00 00</a>
+            <a href="mailto:contact@tennisimpact.fr">contact@tennisimpact.fr</a>
+            <span>14 avenue du Court Central · Bordeaux</span>
+          </div>
         </div>
       </nav>
     </div>
@@ -536,18 +546,89 @@
     const header = document.querySelector('.site-header');
     const toggle = document.querySelector('.nav-toggle');
     const nav = document.getElementById('primaryNav');
-    toggle.addEventListener('click', () => {
-      const isOpen = header.classList.toggle('is-open');
-      toggle.setAttribute('aria-expanded', isOpen);
-    });
-    nav.querySelectorAll('a').forEach((link) => {
-      link.addEventListener('click', () => {
+    const body = document.body;
+    const focusableSelectors = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled])';
+    let lastFocusedElement = null;
+
+    const getFocusableElements = () =>
+      nav ? Array.from(nav.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('disabled')) : [];
+
+    const closeMenu = () => {
+      if (!header || !toggle) return;
+      header.classList.remove('is-open');
+      body.classList.remove('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
+    };
+
+    const openMenu = () => {
+      if (!header || !toggle) return;
+      lastFocusedElement = document.activeElement;
+      header.classList.add('is-open');
+      body.classList.add('has-menu-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      const focusable = getFocusableElements();
+      if (focusable.length) {
+        focusable[0].focus();
+      }
+    };
+
+    if (toggle && nav) {
+      toggle.addEventListener('click', () => {
         if (header.classList.contains('is-open')) {
-          header.classList.remove('is-open');
-          toggle.setAttribute('aria-expanded', 'false');
+          closeMenu();
+        } else {
+          openMenu();
         }
       });
-    });
+
+      nav.querySelectorAll('a').forEach((link) =>
+        link.addEventListener('click', () => {
+          closeMenu();
+        })
+      );
+
+      const handleDesktopChange = (event) => {
+        if (event.matches) {
+          closeMenu();
+        }
+      };
+
+      const mediaQuery = window.matchMedia('(min-width: 1025px)');
+      handleDesktopChange(mediaQuery);
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', handleDesktopChange);
+      } else {
+        mediaQuery.addListener(handleDesktopChange);
+      }
+
+      document.addEventListener('keydown', (event) => {
+        if (!header.classList.contains('is-open')) return;
+
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeMenu();
+          toggle.focus();
+        } else if (event.key === 'Tab') {
+          const focusable = getFocusableElements();
+          if (!focusable.length) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      });
+    }
+
     document.getElementById('currentYear').textContent = new Date().getFullYear();
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -52,6 +52,10 @@ body {
   min-height: 100vh;
 }
 
+body.has-menu-open {
+  overflow: hidden;
+}
+
 body::before {
   content: "";
   position: fixed;
@@ -246,6 +250,19 @@ img {
   align-items: center;
   gap: 1.5rem;
   font-size: 0.95rem;
+  margin-left: auto;
+}
+
+.site-nav__content {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.site-nav__links {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
 }
 
 .site-nav__link {
@@ -278,6 +295,25 @@ img {
   display: flex;
   align-items: center;
   gap: 1rem;
+}
+
+.site-nav__meta {
+  display: none;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  text-align: left;
+}
+
+.site-nav__meta strong {
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.site-nav__meta a {
+  color: inherit;
+  font-weight: 500;
 }
 
 .nav-toggle {
@@ -1137,34 +1173,115 @@ th {
   }
 
   .site-nav {
-    position: absolute;
-    top: calc(100% + 1rem);
-    right: 1.5rem;
-    background: var(--surface);
-    border-radius: var(--radius-md);
-    padding: 1.5rem;
+    position: fixed;
+    inset: 0;
+    padding: clamp(4rem, 10vh, 6rem) clamp(1.5rem, 6vw, 3rem);
+    background: transparent;
     flex-direction: column;
-    align-items: flex-start;
-    gap: 1rem;
-    box-shadow: var(--shadow-lg);
+    justify-content: center;
+    align-items: stretch;
+    gap: 0;
+    pointer-events: none;
     opacity: 0;
     visibility: hidden;
     transform: translateY(-10px);
+    transition: var(--transition);
+    z-index: 999;
+    isolation: isolate;
   }
 
-  .site-header.is-open .site-nav {
-    opacity: 1;
-    visibility: visible;
+  .site-nav::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+      radial-gradient(circle at 20% 20%, rgba(249, 223, 206, 0.24), transparent 58%),
+      radial-gradient(circle at 80% 0%, rgba(32, 146, 161, 0.32), transparent 60%),
+      linear-gradient(160deg, rgba(12, 59, 67, 0.96), rgba(10, 42, 48, 0.98));
+    z-index: -1;
+    opacity: 0.98;
+  }
+
+  .site-nav__content {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(2.2rem, 6vw, 3.4rem);
+    width: min(520px, 100%);
+    margin: 0 auto;
+  }
+
+  .site-nav__links {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: clamp(1rem, 3vw, 1.6rem);
+  }
+
+  .site-nav__link {
+    font-size: clamp(1.5rem, 5.5vw, 2.4rem);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--text-inverse);
+  }
+
+  .site-nav__link::after {
+    display: none;
   }
 
   .site-nav__cta {
     width: 100%;
     flex-direction: column;
     align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .site-nav__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+    color: var(--text-muted);
+  }
+
+  .site-nav__meta strong,
+  .site-nav__meta span,
+  .site-nav__meta a {
+    color: var(--text-inverse);
   }
 
   .nav-toggle {
     display: inline-flex;
+  }
+
+  .site-header.is-open {
+    background: transparent;
+    border-bottom-color: transparent;
+  }
+
+  .site-header.is-open .site-nav {
+    pointer-events: auto;
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  .site-header.is-open .brand {
+    color: var(--text-inverse);
+  }
+
+  .site-header.is-open .brand img {
+    border-color: rgba(249, 223, 206, 0.52);
+  }
+
+  .site-header.is-open .nav-toggle {
+    background: rgba(247, 252, 253, 0.08);
+    border-color: rgba(247, 252, 253, 0.24);
+  }
+
+  .site-header.is-open .nav-toggle span,
+  .site-header.is-open .nav-toggle::before,
+  .site-header.is-open .nav-toggle::after {
+    background: var(--text-inverse);
   }
 }
 


### PR DESCRIPTION
## Summary
- restructure header navigation across Pilates and Tennis pages to include grouped links, CTAs, and contact details for the overlay experience
- add an accessible toggle script with focus management, escape handling, and body scroll locking to every page script
- refresh responsive styles to render a gradient full-screen menu on mobile while preserving the desktop layout

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fce42aec08325b98c3f7d29862aca)